### PR TITLE
First draft of treasury. Not meant to be merged

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/IVault.sol";
 import "./interfaces/IKeyManager.sol";
+import "./interfaces/ITreasury.sol";
 import "./interfaces/IERC20Lite.sol";
 import "./abstract/Shared.sol";
 import "./DepositEth.sol";
@@ -20,10 +21,26 @@ contract Vault is IVault, Shared {
 
     /// @dev    The KeyManager used to checks sigs used in functions here
     IKeyManager private _keyManager;
+    /// @dev    The Treasury which lends out most of the assets held
+    ///         by CF on Ethereum
+    ITreasury private _treasury;
+    // Lending parameters
+    /// @dev    The upper bound percent of an asset held by CF contracts on ETH such
+    ///         that enough is lent out to return it to the mid range of the bounds.
+    ///         Max BPS is 10000
+    uint constant public UPPER_LEND_BPS = 2000;
+    /// @dev    The lower bound percent of an asset held by CF contracts on ETH such
+    ///         that enough is withdrawn from lending platforms to return it
+    ///         to the mid range of the bounds. Max BPS is 10000
+    uint constant public LOWER_LEND_BPS = 1000;
 
 
-    constructor(IKeyManager keyManager) {
+    constructor(IKeyManager keyManager, ITreasury treasury) {
         _keyManager = keyManager;
+        // Might want to change this to creating the contract
+        // here instead? Can't do it yet without an implementation
+        // of treasury
+        _treasury = treasury;
     }
 
 
@@ -247,6 +264,51 @@ contract Vault is IVault, Shared {
 
         for (uint i; i < swapIDs.length; i++) {
             new DepositToken{salt: swapIDs[i]}(IERC20Lite(tokenAddrs[i]));
+        }
+    }
+
+
+    //////////////////////////////////////////////////////////////
+    //                                                          //
+    //                          Treasury                        //
+    //                                                          //
+    //////////////////////////////////////////////////////////////
+
+    /**
+     * @notice  Checks whether a group of tokens are above or below the upper bounds
+     *          of this Vault 'hot wallet', and rebalances the wallet if outside those
+     *          bounds by lending some out or withdrawing some back in.
+     * @param tokens    The array (address[]) of tokens to check the balances/bounds of
+     */
+    function balanceTreasury(IERC20[] calldata tokens) external {
+        for (uint i; i < tokens.length; i++) {
+            uint vaultBal;
+            uint treasuryBal = _treasury.getLentAmount(tokens[i]);
+
+            if (address(tokens[i]) == _ETH_ADDR) {
+                vaultBal = address(this).balance;
+            } else {
+                vaultBal = tokens[i].balanceOf(address(this));
+            }
+
+            uint totalBal = vaultBal + treasuryBal;
+            uint percent = _MAX_BPS * vaultBal / totalBal;
+            uint targetPercent = (UPPER_LEND_BPS + LOWER_LEND_BPS) / 2;
+
+            if (percent > UPPER_LEND_BPS) {
+                uint amount = (percent - targetPercent) * totalBal;
+
+                if (address(tokens[i]) == _ETH_ADDR) {
+                    payable(address(_treasury)).transfer(amount);
+                } else {
+                    tokens[i].transfer(address(_treasury), amount);
+                }
+
+                _treasury.lend();
+            } else if (percent < LOWER_LEND_BPS) {
+                uint amount = (targetPercent - percent) * totalBal;
+                _treasury.withdraw(tokens[i], amount);
+            }
         }
     }
 

--- a/contracts/abstract/Shared.sol
+++ b/contracts/abstract/Shared.sol
@@ -16,6 +16,7 @@ abstract contract Shared is IShared {
     address constant internal _ZERO_ADDR = address(0);
     bytes32 constant internal _NULL = "";
     uint constant internal _E_18 = 10**18;
+    uint constant internal _MAX_BPS = 10000;
 
 
     /// @dev    Checks that a uint isn't nonzero/empty

--- a/contracts/interfaces/ITreasury.sol
+++ b/contracts/interfaces/ITreasury.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.8.0;
+
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+
+interface ITreasury {
+
+    /**
+     * @notice  Checks the Treasury's balance of all supported assets and
+     *          lends them out if they're non-zero. Updates the record
+     *          of how much of each asset is currently lent out (not including
+     *          the interest/yield)
+     */
+    function lend() external;
+
+    /**
+     * @notice  Withdraw a specific amount from lending platforms and send it to the Vault.
+     *          Since this Vault shouldn't have any knowledge of what lending platforms
+     *          etc are used, it should trust the Treasury to calculate how much needs
+     *          to be withdrawn from whatever platform such that the initially lent
+     *          amount + interest equals amount.
+     * @param asset The address of the asset to withdraw
+     * @param amount    The amount to send to the Vault. The amount withdrawn from the
+     *                  actual lending platforms will be less as the Treasury accounts
+     *                  for interest/yield received after withdrawing
+     */
+    function withdraw(IERC20 asset, uint amount) external;
+
+    /**
+     * @notice  Gets the amount of an asset that's been lent out in total over
+     *          various platforms incl yield. The Vault needs to know this so that it can
+     *          calculate whether its own balance is within its own 'hot wallet'
+     *          bounds and therefore withdraw some if it's low or send & lend if
+     *          it has too much
+     * @return  The amount of that asset that's been lent out (uint)
+     */
+    function getLentAmount(IERC20 asset) external returns (uint);
+}


### PR DESCRIPTION
Technically it's a public holiday and also the start of my vacation buttt I wanted to merge this to give people time to think about this more concretely while I'm away rather than rush on it when I'm back.

Thoughts:
 - I had a few iterations, like having `balanceTreasury` be a modifier that was called at the start or end of every fcn, but there's alot of overhead with doing that (getting a unique list of tokens to check from an array that can contain the same token multiple times, and then checking the balances of multiple contracts to know how much can be withdrawn from lending platforms for each token, which can get pretty expensive just for one lending platform per token since it requires reading alot of its state, let alone multiple). So I added a bool as input to each fcn that determines whether the checks on the treasury balances should be done so that the CFE can determine when it's worth doing the check (i.e. any time a token is out of bounds and the check will therefore actually do something and cause a rebalance) - at that point it might aswell just become its own fcn, which is nice because it eliminates some of the overhead of having to get a unique array of tokens since that can be chosen as input by the caller
 - I don't see a reason to require a sig from the CFE? So anyone should be able to call this
 - Then, who should pay? Tho this issue is present whether it's a modifier on batch txs or a standalone tx like it is here, since it's not really a user's fault if part of their swap is included in a tx that ends up rebalancing and making the tx cost 5x more
 - I currently have it so that the Vault sends excess funds directly to the Treasury, but maybe the treasury should handle the transfers? Would be cleaner in the Vault, but it also arguably introduces more attack surface since the Treasury is alot more exposed to external contracts.