### PR TITLE
Adding a 'deploy all events' function for use in integration tests

### DIFF
--- a/scripts/deploy_and.py
+++ b/scripts/deploy_and.py
@@ -30,6 +30,13 @@ print("======================================================================")
 def main():
     print()
 
+def all_events():
+    print(f"\n-- Stake Manager Events --\n")
+    all_stakeManager_events()
+    chain.sleep(CLAIM_DELAY)
+    print(f"\n-- Key Manager Events --\n")
+    all_keyManager_events()
+
 def all_stakeManager_events():
     print(f"\n💰 Alice stakes {MIN_STAKE} with nodeID {JUNK_INT}\n")
     cf.stakeManager.stake(JUNK_INT, MIN_STAKE, NON_ZERO_ADDR, {'from': ALICE})


### PR DESCRIPTION
Added a simple `all_events` function that runs both `all_stakeManager_events` and  `all_keyManager_events` with a delay.
Running the functions separately resulted in an error because it would try and deploy the contracts again. The short delay was only necessary if the events were in a different order, but i left it in anyway.
Now both the Stake Manager and Key Manager integration test can be ran after `all_events` has been ran.