### PR TITLE
Add msg.sender to the staked event

### DIFF
--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -61,7 +61,7 @@ contract StakeManager is Shared, IStakeManager, IERC777Recipient {
     // }
 
 
-    event Staked(bytes32 indexed nodeID, uint amount, address returnAddr);
+    event Staked(bytes32 indexed nodeID, uint amount, address staker, address returnAddr);
     event ClaimRegistered(
         bytes32 indexed nodeID,
         uint amount,
@@ -114,7 +114,7 @@ contract StakeManager is Shared, IStakeManager, IERC777Recipient {
         require(_FLIP.balanceOf(address(this)) == balBefore + amount, "StakeMan: token transfer failed");
 
         _totalStake += amount;
-        emit Staked(nodeID, amount, returnAddr);
+        emit Staked(nodeID, amount, msg.sender, returnAddr);
     }
 
     /**

--- a/tests/shared_tests.py
+++ b/tests/shared_tests.py
@@ -111,7 +111,7 @@ def isValidSig_rev_test(cf, signer):
 # `stakedMin` directly
 def stakeTest(cf, prevTotal, nodeID, minStake, tx, amount, returnAddr):
     assert cf.flip.balanceOf(cf.stakeManager) == prevTotal + amount + STAKEMANAGER_INITIAL_BALANCE
-    assert tx.events["Staked"][0].values() == [nodeID, amount, returnAddr]
+    assert tx.events["Staked"][0].values() == [nodeID, amount, tx.sender, returnAddr]
     assert cf.stakeManager.getMinimumStake() == minStake
 
 


### PR DESCRIPTION
@kylezs this will require an update to the CFE's event watcher which I have captured here: [CH-2060](https://app.shortcut.com/chainflip/story/2060/add-msg-sender-to-staked-event-parser)

@cncrde once the above ticket is closed by Kyle and we deploy a new set of contracts to ping the tests against, you should be good to go.