### PR TITLE
Fix to allow zero address as refund address

### DIFF
--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -97,14 +97,14 @@ contract StakeManager is Shared, IStakeManager, IERC777Recipient {
      * @dev             Requires the staker to have called `approve` in FLIP
      * @param amount    The amount of stake to be locked up
      * @param nodeID    The nodeID of the staker
-     * @param returnAddr    The address which the staker requires to be used
-     *                      when claiming back FLIP for `nodeID`
+     * @param returnAddr    Optional address to be referenced by Claim Sigs. If
+     *                      zero, any address can be used.
      */
     function stake(
         bytes32 nodeID,
         uint amount,
         address returnAddr
-    ) external override nzBytes32(nodeID) nzAddr(returnAddr) noFish {
+    ) external override nzBytes32(nodeID) noFish {
         require(amount >= _minStake, "StakeMan: stake too small");
 
         // Ensure FLIP is transferred and update _totalStake. Technically this `require` shouldn't

--- a/tests/unit/stakeManager/test_stake.py
+++ b/tests/unit/stakeManager/test_stake.py
@@ -36,6 +36,10 @@ def test_stake_min(cf, stakedMin):
     )
 
 
+def test_stake_zero_addr(cf):
+    cf.stakeManager.stake(JUNK_HEX, MIN_STAKE, ZERO_ADDR, {'from': cf.ALICE})
+
+
 def test_stake_rev_amount_just_under_minStake(cf):
     with reverts(REV_MSG_MIN_STAKE):
         cf.stakeManager.stake(JUNK_HEX, MIN_STAKE-1, NON_ZERO_ADDR, {'from': cf.ALICE})


### PR DESCRIPTION
@kylezs @Janislav this should be the fix required by: https://github.com/chainflip-io/chainflip-backend/pull/590

@dandanlen we might need to have a quick chat so I can validate the assumptions I'm making about the refund address storage.