### PR TITLE
style: Solhint turn off reason string check

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -14,6 +14,7 @@
       }
     ],
     "not-rely-on-time": "off",
-    "no-empty-blocks": "off"
+    "no-empty-blocks": "off",
+    "reason-string": "off"
   }
 }

--- a/contracts/KeyManager.sol
+++ b/contracts/KeyManager.sol
@@ -250,9 +250,6 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
         // address of this contract, otherwise calling setAggKeyWithAggKey
         // from any address would fail the whitelist check
         
-        // Disable check for reason-string because require should not fail. The function
-        // inside should either revert or return true, never false. Require just seems healthy
-        // solhint-disable-next-line reason-string
         require(this.isUpdatedValidSig(sigData, contractMsgHash));
         _;
     }

--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -115,8 +115,6 @@ contract StakeManager is
         // be necessary, but since this is mission critical, it's worth being paranoid
         uint256 balBefore = flip.balanceOf(address(this));
         // Assumption of set token allowance by the user
-        // Disable because it would revert inside the transfer providing a reason-string
-        // solhint-disable-next-line reason-string
         require(_FLIP.transferFrom(msg.sender,address(this), amount));
         require(
             flip.balanceOf(address(this)) == balBefore + amount,
@@ -198,8 +196,6 @@ contract StakeManager is
         emit ClaimExecuted(nodeID, claim.amount);
 
         // Send the tokens
-        // Disable because it would revert inside the transfer providing a reason-string
-        // solhint-disable-next-line reason-string
         require(_FLIP.transfer(claim.staker, claim.amount));
     }
 
@@ -286,8 +282,6 @@ contract StakeManager is
         require(suspended, "Staking: Not suspended");
         address to = _keyManager.getGovernanceKey();
         uint256 amount = _FLIP.balanceOf(address(this));
-        // Disable because it would revert inside the transfer providing a reason-string
-        // solhint-disable-next-line reason-string
         require(_FLIP.transfer(to, amount));
         emit GovernanceWithdrawal(to, amount);
     }

--- a/contracts/TokenVesting.sol
+++ b/contracts/TokenVesting.sol
@@ -72,8 +72,6 @@ contract TokenVesting is ReentrancyGuard {
         bool canStake_,
         IStakeManager stakeManager_
     ) {
-        // Disable reason length - it can't be made short enough
-        // solhint-disable reason-string
         require(beneficiary_ != address(0), "Vesting: beneficiary_ is the zero address");
         require(revoker_ != address(0), "Vesting: revoker_ is the zero address");
         require(start_ > 0, "Vesting: start_ is 0");
@@ -82,7 +80,6 @@ contract TokenVesting is ReentrancyGuard {
         require(end_ > block.timestamp, "Vesting: final time is before current time");
         require(address(stakeManager_) != address(0), "Vesting: stakeManager_ is the zero address");
         if (canStake_) require (cliff_ == end_ , "Vesting: invalid staking contract cliff");
-        // solhint-enable reason-string
 
         beneficiary = beneficiary_;
         revoker = revoker_;

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -365,9 +365,6 @@ contract Vault is IVault, Shared {
         SigData calldata sigData,
         bytes32 contractMsgHash
     ) {
-        // Disable check for reason-string because require should not fail. The function
-        // inside should either revert or return true, never false. Require just seems healthy
-        // solhint-disable-next-line reason-string
         require(_keyManager.isUpdatedValidSig(sigData, contractMsgHash));
         _;
     }

--- a/contracts/mocks/StakeManagerVulnerable.sol
+++ b/contracts/mocks/StakeManagerVulnerable.sol
@@ -40,8 +40,6 @@ contract StakeManagerVulnerable is StakeManager {
      * @param amount    The amount of FLIP to send
      */
     function testSendFLIP(address receiver, uint256 amount) external {
-        // Disable because it would revert inside the transfer providing a reason-string
-        // solhint-disable-next-line reason-string
         require(_FLIP.transfer(receiver, amount));
     }
 }


### PR DESCRIPTION
Solhint turn off reason string check. That seems to be common practice as there are many instances on where not having a revert string for the all the requires makes sense. 