### PR TITLE
fix: Fix chaintime issue causing tests to sometimes fail

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,7 @@ from deploy import deploy_initial_Chainflip_contracts
 from deploy import deploy_set_Chainflip_contracts
 from brownie import chain
 from brownie.network import priority_fee
+from utils import *
 
 
 # Test isolation
@@ -115,7 +116,7 @@ def stakedMin(cf):
 @pytest.fixture(scope="module")
 def claimRegistered(cf, stakedMin):
     _, amount = stakedMin
-    expiryTime = chain.time() + (2 * CLAIM_DELAY)
+    expiryTime = getChainTime() + (2 * CLAIM_DELAY)
     args = (JUNK_HEX, amount, cf.DENICE, expiryTime)
 
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
@@ -228,7 +229,7 @@ def tokenVestingNoStaking(addrs, cf, TokenVesting):
 
     # This was hardcoded to a timestamp, but ganache uses real-time when we run
     # the tests, so we should use relative values instead of absolute ones
-    start = chain.time()
+    start = getChainTime()
     cliff = start + QUARTER_YEAR
     end = start + QUARTER_YEAR + YEAR
 
@@ -256,7 +257,7 @@ def tokenVestingStaking(addrs, cf, TokenVesting):
 
     # This was hardcoded to a timestamp, but ganache uses real-time when we run
     # the tests, so we should use relative values instead of absolute ones
-    start = chain.time()
+    start = getChainTime()
     end = start + QUARTER_YEAR + YEAR
     cliff = end
 

--- a/tests/integration/keyManager/test_isValidSig_setKey.py
+++ b/tests/integration/keyManager/test_isValidSig_setKey.py
@@ -4,8 +4,6 @@ from brownie import reverts, chain
 
 
 def test_isValidSig_setAggKeyWithAggKey_validate(cfAW):
-    # txTimeTest(cfAW.keyManager.getLastValidateTime(), cfAW.keyManager.tx)
-
     # Should validate with current keys and revert with future keys
     isValidSig_test(cfAW, AGG_SIGNER_1)
     isValidSig_rev_test(cfAW, AGG_SIGNER_2)
@@ -19,8 +17,6 @@ def test_isValidSig_setAggKeyWithAggKey_validate(cfAW):
 
 
 def test_isValid_setGovKeyWithGovKey_isValid_setAggKeyWithGovKey_isValidSig(cfAW):
-    # txTimeTest(cfAW.keyManager.getLastValidateTime(), cfAW.keyManager.tx)
-
     # Should validate with current keys and revert with future keys
     isValidSig_test(cfAW, AGG_SIGNER_1)
     isValidSig_rev_test(cfAW, AGG_SIGNER_2)
@@ -48,7 +44,7 @@ def test_isValid_setGovKeyWithGovKey_isValid_setAggKeyWithGovKey_isValidSig(cfAW
 
     assert cfAW.keyManager.getAggregateKey() == AGG_SIGNER_2.getPubDataWith0x()
     assert cfAW.keyManager.getGovernanceKey() == cfAW.GOVERNOR_2
-    # txTimeTest(cfAW.keyManager.getLastValidateTime(), tx)
+
     assert tx.events["AggKeySetByGovKey"][0].values() == [
         AGG_SIGNER_1.getPubDataWith0x(),
         AGG_SIGNER_2.getPubDataWith0x(),

--- a/tests/integration/keyManager/test_setKey_setKey.py
+++ b/tests/integration/keyManager/test_setKey_setKey.py
@@ -33,7 +33,6 @@ def test_setAggKeyWithAggKey_setAggKeyWithAggKey(cfAW):
         AGG_SIGNER_1.getPubDataWith0x(),
     ]
     assert cfAW.keyManager.getGovernanceKey() == cfAW.GOVERNOR
-    # txTimeTest(cfAW.keyManager.getLastValidateTime(), tx)
 
 
 def test_setGovKeyWithGovKey_setAggKeyWithGovKey(cfAW):
@@ -66,7 +65,6 @@ def test_setGovKeyWithGovKey_setAggKeyWithGovKey(cfAW):
         AGG_SIGNER_2.getPubDataWith0x(),
     ]
     assert cfAW.keyManager.getGovernanceKey() == cfAW.GOVERNOR_2
-    # txTimeTest(cfAW.keyManager.getLastValidateTime(), tx)
 
 
 # Check that _setAggKeyWithAggKey updates the _lastValidateTime

--- a/tests/integration/stakeManager/test_claim_updateFlipSupply.py
+++ b/tests/integration/stakeManager/test_claim_updateFlipSupply.py
@@ -1,6 +1,7 @@
 from consts import *
 from shared_tests import *
 from brownie import web3, chain
+from utils import *
 
 
 def test_registerClaim_updateFlipSupply_executeClaim(cf, stakedMin):
@@ -9,7 +10,12 @@ def test_registerClaim_updateFlipSupply_executeClaim(cf, stakedMin):
     receiver = cf.DENICE
 
     registerClaimTest(
-        cf, JUNK_HEX, MIN_STAKE, claimAmount, receiver, chain.time() + (2 * CLAIM_DELAY)
+        cf,
+        JUNK_HEX,
+        MIN_STAKE,
+        claimAmount,
+        receiver,
+        getChainTime() + (2 * CLAIM_DELAY),
     )
 
     stateChainBlockNumber = 1

--- a/tests/integration/stakeManager/test_stake_claim.py
+++ b/tests/integration/stakeManager/test_stake_claim.py
@@ -1,6 +1,7 @@
 from consts import *
 from shared_tests import *
 from brownie import reverts, web3, chain
+from utils import *
 
 
 def test_registerClaim_stake_executeClaim_stake_registerClaim_executeClaim(cf):
@@ -8,12 +9,12 @@ def test_registerClaim_stake_executeClaim_stake_registerClaim_executeClaim(cf):
 
     nodeID1 = web3.toHex(1)
     stakeAmount1 = MIN_STAKE * 3
-    expiryTime1 = chain.time() + (CLAIM_DELAY * 2)
+    expiryTime1 = getChainTime() + (CLAIM_DELAY * 2)
     claimAmount1 = 12345 * E_18
 
     nodeID2 = web3.toHex(2)
     stakeAmount2 = MIN_STAKE * 7
-    expiryTime2 = chain.time() + (CLAIM_DELAY * 3)
+    expiryTime2 = getChainTime() + (CLAIM_DELAY * 3)
     claimAmount2 = claimAmount1 * 2
 
     # Register claim

--- a/tests/shared_tests.py
+++ b/tests/shared_tests.py
@@ -129,7 +129,6 @@ def setKey_rev_sig_test(cf, fcn, signer):
 def isValidSig_test(cf, signer):
     sigData = signer.getSigData(JUNK_HEX_PAD, cf.keyManager.address)
     tx = cf.keyManager.isUpdatedValidSig(sigData, cleanHexStr(sigData[2]))
-    # txTimeTest(cf.keyManager.getLastValidateTime(), tx)
 
 
 def isValidSig_rev_test(cf, signer):

--- a/tests/stateful/test_all.py
+++ b/tests/stateful/test_all.py
@@ -1051,7 +1051,7 @@ def test_all(
 
             current_governor = random.choice([st_sender, self.governor])
 
-            if chain.time() - self.lastValidateTime < AGG_KEY_TIMEOUT:
+            if getChainTime() - self.lastValidateTime < AGG_KEY_TIMEOUT:
                 print(
                     "        REV_MSG_DELAY rule_setAggKeyWithGovKey",
                     st_sender,
@@ -1149,7 +1149,12 @@ def test_all(
         def rule_registerClaim(
             self, st_nodeID, st_staker, st_amount, st_sender, st_expiry_time_diff
         ):
-            args = (st_nodeID, st_amount, st_staker, chain.time() + st_expiry_time_diff)
+            args = (
+                st_nodeID,
+                st_amount,
+                st_staker,
+                getChainTime() + st_expiry_time_diff,
+            )
             callDataNoSig = self.sm.registerClaim.encode_input(
                 agg_null_sig(self.km.address, chain.id), *args
             )
@@ -1185,7 +1190,7 @@ def test_all(
                         *args,
                         {"from": st_sender},
                     )
-            elif chain.time() <= self.pendingClaims[st_nodeID][3]:
+            elif getChainTime() <= self.pendingClaims[st_nodeID][3]:
                 print("        REV_MSG_CLAIM_EXISTS rule_registerClaim", *args)
                 with reverts(REV_MSG_CLAIM_EXISTS):
                     self.sm.registerClaim(
@@ -1227,7 +1232,7 @@ def test_all(
         def rule_executeClaim(self, st_nodeID, st_sender):
             claim = self.pendingClaims[st_nodeID]
 
-            if not claim[2] <= chain.time() <= claim[3]:
+            if not claim[2] <= getChainTime() <= claim[3]:
                 print("        REV_MSG_NOT_ON_TIME rule_executeClaim", st_nodeID)
                 with reverts(REV_MSG_NOT_ON_TIME):
                     self.sm.executeClaim(st_nodeID, {"from": st_sender})

--- a/tests/stateful/test_keyManager.py
+++ b/tests/stateful/test_keyManager.py
@@ -165,7 +165,7 @@ def test_keyManager(BaseStateMachine, state_machine, a, cfDeployAllWhitelist):
 
         # Call setAggKeyWithGovKey with a random new key, signing key, and sender
         def rule_setAggKeyWithGovKey(self, st_sender, st_sig_key_idx, st_new_key_idx):
-            if chain.time() - self.lastValidateTime < AGG_KEY_TIMEOUT:
+            if getChainTime() - self.lastValidateTime < AGG_KEY_TIMEOUT:
                 print(
                     "        REV_MSG_DELAY rule_setAggKeyWithGovKey",
                     st_sender,

--- a/tests/stateful/test_stakeManager.py
+++ b/tests/stateful/test_stakeManager.py
@@ -153,7 +153,12 @@ def test_stakeManager(BaseStateMachine, state_machine, a, cfDeploy):
             st_sender,
             st_expiry_time_diff,
         ):
-            args = (st_nodeID, st_amount, st_staker, chain.time() + st_expiry_time_diff)
+            args = (
+                st_nodeID,
+                st_amount,
+                st_staker,
+                getChainTime() + st_expiry_time_diff,
+            )
             callDataNoSig = self.sm.registerClaim.encode_input(
                 agg_null_sig(self.km.address, chain.id), *args
             )
@@ -189,7 +194,7 @@ def test_stakeManager(BaseStateMachine, state_machine, a, cfDeploy):
                         *args,
                         {"from": st_sender},
                     )
-            elif chain.time() <= self.pendingClaims[st_nodeID][3]:
+            elif getChainTime() <= self.pendingClaims[st_nodeID][3]:
                 print("        REV_MSG_CLAIM_EXISTS rule_registerClaim", *args)
                 with reverts(REV_MSG_CLAIM_EXISTS):
                     self.sm.registerClaim(
@@ -243,7 +248,7 @@ def test_stakeManager(BaseStateMachine, state_machine, a, cfDeploy):
         def rule_executeClaim(self, st_nodeID, st_sender):
             claim = self.pendingClaims[st_nodeID]
 
-            if not claim[2] <= chain.time() <= claim[3]:
+            if not claim[2] <= getChainTime() <= claim[3]:
                 print("        REV_MSG_NOT_ON_TIME rule_executeClaim", st_nodeID)
                 with reverts(REV_MSG_NOT_ON_TIME):
                     self.sm.executeClaim(st_nodeID, {"from": st_sender})

--- a/tests/token_vesting/release/test_release_nostaking.py
+++ b/tests/token_vesting/release/test_release_nostaking.py
@@ -18,7 +18,7 @@ def test_release(addrs, cf, tokenVestingNoStaking, maths, sleepTime):
 
     chain.sleep(sleepTime)
 
-    if chain.time() < cliff:
+    if getChainTime() < cliff:
         release_revert(tv, cf, addrs.INVESTOR)
     else:
         tx = tv.release(cf.flip, {"from": addrs.INVESTOR})

--- a/tests/token_vesting/release/test_release_staking.py
+++ b/tests/token_vesting/release/test_release_staking.py
@@ -20,7 +20,7 @@ def test_release(addrs, cf, tokenVestingStaking, maths, sleepTime):
 
     assert tv.cliff() == tv.end()
 
-    if chain.time() < end:
+    if getChainTime() < end:
         release_revert(tv, cf, addrs.INVESTOR)
     else:
         tx = tv.release(cf.flip, {"from": addrs.INVESTOR})
@@ -84,7 +84,7 @@ def test_consecutive_releases_after_cliff(addrs, cf, tokenVestingStaking, maths)
     for timestamp in timestamps:
 
         chain.sleep(timestamp - previousTimestamp)
-        if chain.time() < end:
+        if getChainTime() < end:
             release_revert(tv, cf, addrs.INVESTOR)
         else:
             tx = tv.release(cf.flip, {"from": addrs.INVESTOR})
@@ -157,7 +157,7 @@ def test_release_around_cliff(addrs, cf, tokenVestingStaking, maths, sleepTime):
 
     chain.sleep(sleepTime)
 
-    if chain.time() >= cliff & cliff == end:
+    if getChainTime() >= cliff & cliff == end:
         tx = tv.release(cf.flip, {"from": addrs.INVESTOR})
         # Check release
         check_released(tv, cf, tx, addrs.INVESTOR, total, total)

--- a/tests/token_vesting/revoke/test_revoke_nostaking.py
+++ b/tests/token_vesting/revoke/test_revoke_nostaking.py
@@ -17,10 +17,10 @@ def test_revoke(addrs, cf, tokenVestingNoStaking, maths, sleepTime):
 
     chain.sleep(sleepTime)
 
-    if chain.time() < cliff:
+    if getChainTime() < cliff:
         tx = tv.revoke(cf.flip, {"from": addrs.REVOKER})
         releasable = 0
-    elif chain.time() >= end:
+    elif getChainTime() >= end:
         with reverts(REV_MSG_VESTING_EXPIRED):
             tv.revoke(cf.flip, {"from": addrs.REVOKER})
         return

--- a/tests/token_vesting/revoke/test_revoke_staking.py
+++ b/tests/token_vesting/revoke/test_revoke_staking.py
@@ -17,10 +17,10 @@ def test_revoke(addrs, cf, tokenVestingStaking, maths, sleepTime):
 
     chain.sleep(sleepTime)
 
-    if chain.time() < cliff:
+    if getChainTime() < cliff:
         tx = tv.revoke(cf.flip, {"from": addrs.REVOKER})
         releasable = 0
-    elif chain.time() >= end:
+    elif getChainTime() >= end:
         with reverts(REV_MSG_VESTING_EXPIRED):
             tv.revoke(cf.flip, {"from": addrs.REVOKER})
         return

--- a/tests/unit/keyManager/test_keyManager_constructor.py
+++ b/tests/unit/keyManager/test_keyManager_constructor.py
@@ -6,7 +6,6 @@ from shared_tests import *
 def test_constructor(a, cf):
     assert cf.keyManager.getAggregateKey() == AGG_SIGNER_1.getPubDataWith0x()
     assert cf.keyManager.getGovernanceKey() == cf.GOVERNOR
-    # txTimeTest(cf.keyManager.getLastValidateTime(), cf.keyManager.tx)
     assert cf.keyManager.canValidateSigSet() == True
     whitelisted = [cf.vault, cf.keyManager, cf.stakeManager]
     for addr in whitelisted + list(a):

--- a/tests/unit/stakeManager/test_registerClaim.py
+++ b/tests/unit/stakeManager/test_registerClaim.py
@@ -12,7 +12,7 @@ from brownie.test import given, strategy
     expiryTimeDiff=strategy("uint", min_value=5, max_value=365 * DAY),
 )
 def test_registerClaim_amount_rand(cf, stakedMin, amount, staker, expiryTimeDiff):
-    args = (JUNK_HEX, amount, staker, chain.time() + CLAIM_DELAY + expiryTimeDiff)
+    args = (JUNK_HEX, amount, staker, getChainTime() + CLAIM_DELAY + expiryTimeDiff)
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
     )
@@ -23,7 +23,7 @@ def test_registerClaim_amount_rand(cf, stakedMin, amount, staker, expiryTimeDiff
             )
     else:
         registerClaimTest(
-            cf, JUNK_HEX, MIN_STAKE, amount, staker, chain.time() + (2 * CLAIM_DELAY)
+            cf, JUNK_HEX, MIN_STAKE, amount, staker, getChainTime() + (2 * CLAIM_DELAY)
         )
 
 
@@ -32,13 +32,13 @@ def test_registerClaim_amount_rand(cf, stakedMin, amount, staker, expiryTimeDiff
 
 def test_registerClaim_min_expiryTime(cf, stakedMin):
     registerClaimTest(
-        cf, JUNK_HEX, MIN_STAKE, MIN_STAKE, cf.DENICE, chain.time() + CLAIM_DELAY + 5
+        cf, JUNK_HEX, MIN_STAKE, MIN_STAKE, cf.DENICE, getChainTime() + CLAIM_DELAY + 5
     )
 
 
 def test_registerClaim_rev_just_under_min_expiryTime(cf, stakedMin):
     _, amount = stakedMin
-    args = (JUNK_HEX, amount, cf.DENICE, chain.time() + CLAIM_DELAY - 5)
+    args = (JUNK_HEX, amount, cf.DENICE, getChainTime() + CLAIM_DELAY - 5)
 
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
@@ -51,7 +51,7 @@ def test_registerClaim_rev_just_under_min_expiryTime(cf, stakedMin):
 
 def test_registerClaim_claim_expired(cf, stakedMin):
     _, amount = stakedMin
-    args = (JUNK_HEX, amount, cf.DENICE, chain.time() + CLAIM_DELAY + 5)
+    args = (JUNK_HEX, amount, cf.DENICE, getChainTime() + CLAIM_DELAY + 5)
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
     )
@@ -61,13 +61,18 @@ def test_registerClaim_claim_expired(cf, stakedMin):
 
     chain.sleep(CLAIM_DELAY + 10)
     registerClaimTest(
-        cf, JUNK_HEX, MIN_STAKE, MIN_STAKE, cf.DENICE, chain.time() + (2 * CLAIM_DELAY)
+        cf,
+        JUNK_HEX,
+        MIN_STAKE,
+        MIN_STAKE,
+        cf.DENICE,
+        getChainTime() + (2 * CLAIM_DELAY),
     )
 
 
 def test_registerClaim_rev_claim_not_expired(cf, stakedMin):
     _, amount = stakedMin
-    args = (JUNK_HEX, amount, cf.DENICE, chain.time() + CLAIM_DELAY + 5)
+    args = (JUNK_HEX, amount, cf.DENICE, getChainTime() + CLAIM_DELAY + 5)
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
     )
@@ -87,7 +92,7 @@ def test_registerClaim_rev_claim_not_expired(cf, stakedMin):
 def test_registerClaim_rev_nodeID(cf, stakedMin):
     _, amount = stakedMin
     receiver = cf.DENICE
-    args = (0, amount, receiver, chain.time() + CLAIM_DELAY + 5)
+    args = (0, amount, receiver, getChainTime() + CLAIM_DELAY + 5)
 
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
@@ -100,7 +105,7 @@ def test_registerClaim_rev_nodeID(cf, stakedMin):
 
 def test_registerClaim_rev_staker(cf, stakedMin):
     _, amount = stakedMin
-    args = (JUNK_HEX, amount, ZERO_ADDR, chain.time() + CLAIM_DELAY + 5)
+    args = (JUNK_HEX, amount, ZERO_ADDR, getChainTime() + CLAIM_DELAY + 5)
 
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
@@ -114,7 +119,7 @@ def test_registerClaim_rev_staker(cf, stakedMin):
 def test_registerClaim_rev_msgHash(cf, stakedMin):
     _, amount = stakedMin
     receiver = cf.DENICE
-    args = (JUNK_HEX, amount, cf.DENICE, chain.time() + CLAIM_DELAY + 5)
+    args = (JUNK_HEX, amount, cf.DENICE, getChainTime() + CLAIM_DELAY + 5)
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
     )
@@ -128,7 +133,7 @@ def test_registerClaim_rev_msgHash(cf, stakedMin):
 def test_registerClaim_rev_sig(cf, stakedMin):
     _, amount = stakedMin
     receiver = cf.DENICE
-    args = (JUNK_HEX, amount, cf.DENICE, chain.time() + CLAIM_DELAY + 5)
+    args = (JUNK_HEX, amount, cf.DENICE, getChainTime() + CLAIM_DELAY + 5)
     callDataNoSig = cf.stakeManager.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args
     )
@@ -146,7 +151,7 @@ def test_registerClaim_rev_sig(cf, stakedMin):
 @given(amount=strategy("uint256", min_value=1, max_value=MIN_STAKE + 1))
 def test_registerClaim_rev_noFish(vulnerableR3ktStakeMan, amount):
     cf, smVuln, _ = vulnerableR3ktStakeMan
-    args = (JUNK_HEX, amount, cf.DENICE, chain.time() + CLAIM_DELAY + 5)
+    args = (JUNK_HEX, amount, cf.DENICE, getChainTime() + CLAIM_DELAY + 5)
 
     callDataNoSig = smVuln.registerClaim.encode_input(
         agg_null_sig(cf.keyManager.address, chain.id), *args

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,4 +1,4 @@
-from brownie import web3
+from brownie import web3, chain
 
 
 def cleanHexStr(thing):
@@ -66,9 +66,9 @@ def getValidTranIdxs(tokens, amounts, prevBal, tok):
     return validEthIdxs
 
 
-# Test with timestamp-1 because of an error where there's a difference of 1s
-# because the evm and local clock were out of sync or something... not 100% sure why,
-# but some tests occasionally fail for this reason even though they succeed most
-# of the time with no changes to the contract or test code
-def txTimeTest(time, tx):
-    assert time >= tx.timestamp and time <= (tx.timestamp + 2)
+# EVM and local clock chain.time() are sometimes out of sync by 1, not sure
+# why. Some tests occasionally fail for this reason even though they succeed most
+# of the time with no changes to the contract or test code. Some testing seems to
+# show that transactions are mined 1 later - so using chain.time()+1 as chain time.
+def getChainTime():
+    return chain.time() + 1


### PR DESCRIPTION
Fix chaintime issue causing tests to sometimes fail.

Chain.time() is not synched to the EVM causing some tests to sometimes fail. There was a comment in utils.py reporting the same issue. After some testing I believe that chain.time() is 1 unit less than the actual EVM mined transaction timestamp. So I have created a function to get the chain time (chain.time + 1). So far this seems to solve the issues and all tests pass. Since it is an intermittent issue I will be paying attention to it and see if it pops up again.