### PR TITLE
[DO NOT MERGE] perf: Vault transfer gas optimization

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -220,6 +220,7 @@ contract Vault is IVault, Shared {
     ) private {
         if (address(token) == _ETH_ADDR) {
             // We might need to add protection for reentrancy but I don't think so
+            // solhint-disable-next-line avoid-low-level-calls
             (bool success, bytes memory data) = recipient.call{value: amount}("");
             if (!success) {
                 emit TransferFailed(recipient, amount, data);


### PR DESCRIPTION
Vault transfer gas optimization.

Changing the try-catch sendETH call (with workaround calling it like an external function) for a low level call.

This way we don't rely on the hardcoded gas by the transfer function, which might run into problems if at some point the opcodes change gas costs (as it has happened before). Also, code looks a lot cleaner once I also remove the sendEth function.

Some trials around gas usage seem to show that it reduces gas costs around 2k and this is the reason why I believe we should consider this. It is an non-negligible gas reduction.

However, we need to think it through and make sure we won't run into problems. Call function makes potential reentrancy a real attack vector but I don't think we have that problem (isUpdatedValid check is done before any contract logic is executed, making the signed message non-reusable because of the nonce being used). Also, we need to consider any other risks.

I have attached two screenshots comparing gas usages running all the non-stateful tests we have. All functions that use "transfer" go down in cost except AllBatch. I am looking into that, it is unclear so far why, especially since transferBatch improves.

Original with this.sendETH:
![gas_this sendETH](https://user-images.githubusercontent.com/53186777/158432847-38ff05fa-5732-4982-b005-9ffd424ebe5f.png)

With call function:
![gas_call](https://user-images.githubusercontent.com/53186777/158432872-6c73dbf0-0c5e-42ed-9948-31ddafb9e070.png)


