### PR TITLE
docs: Add precommit install command to setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ yarn
 poetry shell
 poetry install
 brownie pm install OpenZeppelin/openzeppelin-contracts@4.0.0
+pre-commit install
 ```
 
 Then, create a `.env` file using `.env.example` as a reference. ~~You will need an infura key to run the tests~~, and a seed to run the deploy script on a live network.


### PR DESCRIPTION
I noticed that pre-commit hooks were not working when cloning the repository from scratch. After some trial and error I found out that the issue is that running "poetry install" installs pre-commit but it doesn't generate the .git/hooks/pre-commit file. I don't really know why, but that seems wrong from the installation point of view.
The way to generate the .git/hooks/pre-commit file is to run the "pre-commit install" command after all the other setup instructions have been run. That generates the missing file and then pre-commit hooks work.