### PR TITLE
[DO NOT MERGE] Only to discuss contract upgradeability

### DIFF
--- a/contracts/FLIP.sol
+++ b/contracts/FLIP.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IFLIP.sol";
 import "./abstract/Shared.sol";
+import "./interfaces/IKeyManager.sol";
+import "./interfaces/IStakeManager.sol";
 
 /**
  * @title    FLIP contract
@@ -13,16 +15,100 @@ import "./abstract/Shared.sol";
  * @author   Quantaf1re (James Key)
  */
 contract FLIP is ERC20, ERC20Burnable, Ownable, Shared {
+
+
+    IKeyManager private _keyManager;
+
+    /// @dev    The last time that the State Chain updated the totalSupply
+    uint256 private _lastSupplyUpdateBlockNum = 0;
+
     constructor(
         string memory name,
         string memory symbol,
         address receiver,
         uint256 mintAmount
     ) ERC20(name, symbol) Ownable() nzAddr(receiver) nzUint(mintAmount) {
+        // To add initial minting logic or do it in another one-time callable function
+        // to not require a reciever (aka StakeManager) when deploying it
         _mint(receiver, mintAmount);
+        // Update Stake's manager _totalStake with the minted amount
     }
 
     function mint(address receiver, uint256 amount) external nzAddr(receiver) nzUint(amount) onlyOwner {
         _mint(receiver, amount);
+    }
+
+    function updateFlipSupply(
+        SigData calldata sigData,
+        uint256 newTotalSupply,
+        uint256 stateChainBlockNumber,
+        IStakeManager stakeManager
+    )
+        external
+        nzUint(newTotalSupply)
+        noFish(stakeManager) /** Slightly modifier version of the Stakemanager's noFish */ 
+        updatedValidSig(
+            sigData,
+            keccak256(
+                abi.encodeWithSelector(
+                    this.updateFlipSupply.selector,
+                    SigData(sigData.keyManAddr, sigData.chainID, 0, 0, sigData.nonce, address(0)),
+                    newTotalSupply,
+                    stateChainBlockNumber,
+                    stakeManager
+                )
+            )
+        )
+    {
+        // Burn and mint FLIP tokens
+        // mint to the stakeManager provided
+        // Store stateChainBlockNumber as _lastSupplyUpdateBlockNum
+        // Update _totalStake stake on the StakeManager
+        // stakeManager.updateTotalStake(bool, amount)
+    }
+
+    /**
+     * @notice  Update KeyManager reference
+                To be called right after deployment to set the key manager and when/if
+                updating the keyManager contract.
+     */
+    function updateKeyManager(
+        SigData calldata sigData,
+        IKeyManager keyManager
+    )
+        external
+        updatedValidSig(
+            sigData,
+            keccak256(
+                abi.encodeWithSelector(
+                    this.updateKeyManager.selector,
+                    SigData(sigData.keyManAddr, sigData.chainID, 0, 0, sigData.nonce, address(0)),
+                    keyManager
+                )
+            )
+        )
+    {
+         _keyManager = keyManager;
+
+    }
+
+
+
+    /// @dev    Call isUpdatedValidSig in _keyManager
+    modifier updatedValidSig(SigData calldata sigData, bytes32 contractMsgHash) {
+        // Disable check for reason-string because it should not trigger. The function
+        // inside should either revert or return true, never false. Require just seems healthy
+        // solhint-disable-next-line reason-string
+        require(_keyManager.isUpdatedValidSig(sigData, contractMsgHash));
+        _;
+    }
+
+    /// @notice Ensure that FLIP can only be withdrawn via `claim`
+    ///         and not any other method
+    ///         Adapted from StakeManagers
+    modifier noFish(IStakeManager stakeManager) {
+        _;
+        // >= because someone could send some tokens to this contract and disable it if it was ==
+        require(balanceOf(address(stakeManager)) >= stakeManager.getTotalStake(), "Staking: something smells fishy");
     }
 }

--- a/contracts/KeyManager.sol
+++ b/contracts/KeyManager.sol
@@ -52,6 +52,26 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
         }
     }
 
+    // Old whitelisted addresses will remain whitelisted. Used when updating other contracts
+    function addCanValidateSig(SigData calldata sigData, address[] calldata addrs) 
+        external
+        updatedValidSig(
+            sigData,
+            keccak256(
+                abi.encodeWithSelector(
+                    this.setAggKeyWithAggKey.selector,
+                    SigData(sigData.keyManAddr, sigData.chainID, 0, 0, sigData.nonce, address(0)),
+                    addrs
+                )
+            )
+        ){
+        for (uint256 i = 0; i < addrs.length; i++) {
+            _canValidateSig[addrs[i]] = true;
+        }
+    }
+
+
+
     /**
      * @notice  Checks the validity of a signature and msgHash, then updates _lastValidateTime
      * @dev     It would be nice to split this up, but these checks

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -18,13 +18,9 @@ contract Vault is IVault, Shared {
     using SafeERC20 for IERC20;
 
     /// @dev    The KeyManager used to checks sigs used in functions here
-    IKeyManager private immutable _keyManager;
+    IKeyManager private _keyManager;
 
     event TransferFailed(address payable indexed recipient, uint256 amount, bytes lowLevelData);
-
-    constructor(IKeyManager keyManager) {
-        _keyManager = keyManager;
-    }
 
     /**
      * @notice  Can do a combination of all fcns in this contract. It first fetches all
@@ -356,6 +352,31 @@ contract Vault is IVault, Shared {
         for (uint256 i; i < swapIDs.length; i++) {
             new DepositToken{salt: swapIDs[i]}(IERC20Lite(address(tokens[i])));
         }
+    }
+
+    /**
+     * @notice  Update KeyManager reference
+                To be called right after deployment to set the key manager and when/if
+                updating the keyManager contract.
+     */
+    function updateKeyManager(
+        SigData calldata sigData,
+        IKeyManager keyManager
+    )
+        external
+        updatedValidSig(
+            sigData,
+            keccak256(
+                abi.encodeWithSelector(
+                    this.fetchDepositTokenBatch.selector,
+                    SigData(sigData.keyManAddr, sigData.chainID, 0, 0, sigData.nonce, address(0)),
+                    keyManager
+                )
+            )
+        )
+    {
+         _keyManager = keyManager;
+
     }
 
     //////////////////////////////////////////////////////////////

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -79,19 +79,6 @@ interface IStakeManager is IShared {
     function executeClaim(bytes32 nodeID) external;
 
     /**
-     * @notice  Compares a given new FLIP supply against the old supply,
-     *          then mints new and burns as appropriate (to/from the StakeManager)
-     * @param sigData               signature over the abi-encoded function params
-     * @param newTotalSupply        new total supply of FLIP
-     * @param stateChainBlockNumber State Chain block number for the new total supply
-     */
-    function updateFlipSupply(
-        SigData calldata sigData,
-        uint256 newTotalSupply,
-        uint256 stateChainBlockNumber
-    ) external;
-
-    /**
      * @notice      Set the minimum amount of stake needed for `stake` to be able
      *              to be called. Used to prevent spamming of stakes.
      * @param newMinStake   The new minimum stake
@@ -133,13 +120,7 @@ interface IStakeManager is IShared {
      * @return  The address of FLIP
      */
     function getFLIP() external view returns (IFLIP);
-
-    /**
-     * @notice  Get the last state chain block number that the supply was updated at
-     * @return  The state chain block number of the last update
-     */
-    function getLastSupplyUpdateBlockNumber() external view returns (uint256);
-
+    
     /**
      * @notice  Get the minimum amount of stake that's required for a bid
      *          attempt in the auction to be valid - used to prevent sybil attacks
@@ -155,4 +136,6 @@ interface IStakeManager is IShared {
      * @return  The claim (Claim)
      */
     function getPendingClaim(bytes32 nodeID) external view returns (Claim memory);
+
+    function getTotalStake() external view returns (uint256);
 }


### PR DESCRIPTION
[DO NOT MERGE] These are notes to discuss tomorrow. No need to read it beforehand.

List of updates:

Vault:

- Added a gated function to update the KeyManager reference.

FLIP:

- Move all the initial mint logic from the StakeManager to the FLIP contract.
- If we want to fully decouple the deployment of FLIP from StakeManager, we should do the initial mint in a one-time callable function gated by onlyOwner. This way we don't need to pass the StakeManager address to the constructor but to that function. Do we want this? Since the FLIP contract is only deployed once, maybe we can just deploy the StakeManager first and then the FLIP. 
TO BE DISCUSSED: Flip first mint.
- Moved UpdateFlipSupply function from StakeManager to FLIP, adding an extra stakeManager reference as an input.
- Added UpdatedValidSig modifier to gate the UpdateFlipSupply function.
- If we want to keep the NoFish safety mechanism on the Stakemanager, the FLIP contract needs to add a call to the StakeManager to update the Stakemanager's _totalStake. That function is gated by a require(msg.sender == FLIP)
- On the same topic, if we also want to noFish mechanism in the FLIP contract when calling UpdateFlipSupply, it needs to be added to the FLIP contract. 
TO BE DISCUSSED: The noFish function which then requires a call from FLIP to StakeManager to update the _totalStake.

- Added a gated function to update the KeyManager reference.

- According to the initial Github Issue, you proposed having a list of addresses that can mint/burn (aka. call the UpdateFlipSupply). Do we want/need that? or it is just enough with gating the function with the KeyManager?


StakeManager:

(Reasons explained in the FLIP changes)
- Removed intial mint logic
- Removed updateFlipSupply
- Added updateTotalStake (callable only by FLIP)
- Removed _lastSupplyUpdateBlockNum
- Removed constructor storage of _keyManager
- Added function to update keyManager addresses (could be done together or separate). Do we need to be able to update FLIP too? We shouldn't aim to do it, just in case there is a huge issue and we need to redeploy the token (although maybe then we could just set the FLIP in the constructor and in case of huge issue just redeploy FLIP & StakeManager).

KeyManager:

- Modify whitelisting setting => adding addCanValidateSig function. Issues: 
	- We might have multiple Stake manager and/or Vaults that need to validate signatures when doing updates. When the stakeManager is updated we pause the Registering claims on the state Chain. But is there any moment when both need to validate signature? And even if that is not the case, the Vault most likely has, since the fetching requires validation (unless we also pause swapping, but that seems unlikely)
If that is the case, an "Addwhitelistaddress" function would make sense (instead of a "ReplaceWhitelistAddresses".
Having said that, replacing the mapping wouldn't work anyway, we would need to use an array and loop through it - but that would be bad for gas purposes. Therefore, do we just add new addresses to the whitelist and leave the remaining ones whitelisted? (regardless of whether multiple Vaults/StakeManagers might need to be active simultaneously.
