### PR TITLE
fix: remove ERC20 burnable inheritance

### DIFF
--- a/contracts/FLIP.sol
+++ b/contracts/FLIP.sol
@@ -1,7 +1,6 @@
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/extensions/ERC20Burnable.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 import "./interfaces/IFLIP.sol";
 import "./abstract/Shared.sol";
@@ -12,7 +11,7 @@ import "./abstract/Shared.sol";
  *           trap fees with
  * @author   Quantaf1re (James Key)
  */
-contract FLIP is ERC20, ERC20Burnable, Ownable, Shared {
+contract FLIP is ERC20, Ownable, Shared {
     constructor(
         string memory name,
         string memory symbol,
@@ -24,5 +23,9 @@ contract FLIP is ERC20, ERC20Burnable, Ownable, Shared {
 
     function mint(address receiver, uint256 amount) external nzAddr(receiver) nzUint(amount) onlyOwner {
         _mint(receiver, amount);
+    }
+
+    function burn(uint256 amount) external nzUint(amount) onlyOwner {
+        _burn(msg.sender, amount);
     }
 }

--- a/contracts/interfaces/IFLIP.sol
+++ b/contracts/interfaces/IFLIP.sol
@@ -8,4 +8,6 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
  */
 interface IFLIP is IERC20 {
     function mint(address receiver, uint256 amount) external;
+
+    function burn(uint256 amount) external;
 }


### PR DESCRIPTION
Removed ERC20 burnable, I had misread it when I introduced it. I thought it was just exposing the burn call function to be called by the owner of token contract but instead it allows all the token owners to call it, which is not what we want.
This will go away anyway once UpdateFlipSupply is in the FLIP token contract, as part of the upcoming contract upgradability feature commit. Then the internal _burn call is enough. Just doing this PR as good practice.