### PR TITLE
Perf/gas optimizations vault

### DIFF
--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -77,13 +77,15 @@ contract Vault is IVault, AggKeyNonceConsumer {
 
         // Fetch all deposits
         uint256 length = fetchSwapIDs.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ) {
             if (address(fetchTokens[i]) == _ETH_ADDR) {
                 new DepositEth{salt: fetchSwapIDs[i]}();
             } else {
                 new DepositToken{salt: fetchSwapIDs[i]}(IERC20Lite(address(fetchTokens[i])));
             }
-            unchecked{++i;}
+            unchecked {
+                ++i;
+            }
         }
 
         // Send all transfers
@@ -188,11 +190,12 @@ contract Vault is IVault, AggKeyNonceConsumer {
         uint256[] calldata amounts
     ) private {
         uint256 length = tokens.length;
-        for (uint256 i = 0; i < length;) {
+        for (uint256 i = 0; i < length; ) {
             _transfer(tokens[i], recipients[i], amounts[i]);
-            unchecked{++i;}
+            unchecked {
+                ++i;
+            }
         }
-
     }
 
     /**
@@ -285,9 +288,11 @@ contract Vault is IVault, AggKeyNonceConsumer {
         )
     {
         uint256 length = swapIDs.length;
-        for (uint256 i; i < length;) {
+        for (uint256 i; i < length; ) {
             new DepositEth{salt: swapIDs[i]}();
-            unchecked{++i;}
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -357,9 +362,11 @@ contract Vault is IVault, AggKeyNonceConsumer {
         require(swapIDs.length == tokens.length, "Vault: arrays not same length");
 
         uint256 length = swapIDs.length;
-        for (uint256 i; i < length;) {
+        for (uint256 i; i < length; ) {
             new DepositToken{salt: swapIDs[i]}(IERC20Lite(address(tokens[i])));
-            unchecked{++i;}
+            unchecked {
+                ++i;
+            }
         }
     }
 


### PR DESCRIPTION
I went gas golfing and found some low-risk gas optimizations in the Vault that could be considered. I initially run some numbers and the savings were low. However, that is because our tests by default do between 1 and 8 swaps per batch. As you can guess (and see below) these savings are not fixed but rather increase when the amount of swaps per batch increase. That is why I think it might be interesting.

There is significant absolute gas savings when doing a lot of swaps per batch ( 6-7K when doing 80-100 swaps). However, it is still a small part of the total gas spent (<1%). Splitting that between all the users ends up being a small cost but if it is something that we can save that piles up over time then it might be worth considering. Especially since I believe it to be very low risk.

Using transferBatch as a proxy for gas savings in batch functions:

- Number of swaps per batch: 1 to 8

Baseline:
 
Vault <Contract>
   └─ transferBatch         -  avg:  102828  avg (confirmed):  146921  low:   40078  high:  279315

Optimized:
 
Vault <Contract>
   └─ transferBatch         -  avg:  102771  avg (confirmed):  146748  low:   40078  high:  278802

Saving = avg:  57  avg (confirmed): 173 low:   -  high:  513


- Number of swaps per batch: 10 to 15

Baseline:
 
Vault <Contract>
   └─ transferBatch         -  avg:  188507  avg (confirmed):  375067  low:   40078  high:  488879

Optimized:
 
Vault <Contract>
   └─ transferBatch         -  avg:  188217  avg (confirmed):  374184  low:   40078  high:  487774

Saving = avg:  290  avg (confirmed): 883  low:   -  high:  1105


- Number of swaps per batch: 80 to 100

Baseline:
 
Vault <Contract>
   └─ transferBatch         -  avg: 1016834  avg (confirmed): 2685239  low:   40078  high: 3218336

Optimized:
 
Vault <Contract>
   └─ transferBatch         -  avg: 1014609  avg (confirmed): 2678420  low:   40078  high: 3211039

Saving = avg:  2225 avg (confirmed): 6819  low:   -  high:  7297

