### PR TITLE
chore: rename broadcaster to signer. Merged from sandstorm-rc

### DIFF
--- a/contracts/interfaces/IKeyManager.sol
+++ b/contracts/interfaces/IKeyManager.sol
@@ -11,7 +11,7 @@ interface IKeyManager is IShared {
     event AggKeySetByAggKey(Key oldKey, Key newKey);
     event AggKeySetByGovKey(Key oldKey, Key newKey);
     event GovKeySetByGovKey(address oldKey, address newKey);
-    event SignatureAccepted(SigData sigData, address broadcaster);
+    event SignatureAccepted(SigData sigData, address signer);
 
     //////////////////////////////////////////////////////////////
     //                                                          //


### PR DESCRIPTION
Renaming broadcaster to signer. Merged from sandstorm-rc.