### PR TITLE
feat: improve airdrop

### DIFF
--- a/scripts/airdrop.py
+++ b/scripts/airdrop.py
@@ -42,17 +42,11 @@ def main():
     DEPLOYER_ACCOUNT_INDEX = int(os.environ.get("DEPLOYER_ACCOUNT_INDEX") or 0)
     DEPLOYER = cf_accs[DEPLOYER_ACCOUNT_INDEX]
 
-    # Acccount running this script (airdropper) should receive the newFLIP amount necessary to do the airdrop
-    # Airdropper should also have enough ETH to pay for all the airdrop transactions
-    # In the local hardhat net use one of the accounts created - the account from the SEED has no eth
-    if chain.id == 4:
-        airdropper = DEPLOYER
-    else:
-        airdropper = accounts[0]
+    airdropper = DEPLOYER
 
     # If using Infura it will break if snapshot_blocknumber < latestblock-100 due to free-plan limitation
     # Use alchemy when running the old flip snapshot function
-    snapshot_blocknumber = int(os.environ.get("SNAPSHOT_BLOCKNUMBER"))
+    snapshot_blocknumber = os.environ.get("SNAPSHOT_BLOCKNUMBER")
 
     # --------------------------- Start of the script logic  ----------------------------
 
@@ -91,7 +85,7 @@ def main():
         if takeSnapshot not in userInputConfirm:
             printAndLog("Script stopped by user")
             return False
-        snapshot(snapshot_blocknumber, rinkebyOldFlip, oldFlipSnapshotFilename)
+        snapshot(int(snapshot_blocknumber), rinkebyOldFlip, oldFlipSnapshotFilename)
     else:
         printAndLog("Skipped old FLIP snapshot - snapshot already taken")
 


### PR DESCRIPTION
Small improvements to airdrop script:
- As you mentioned in the PR review, when spinning hardhat within the same run, the SEED account gets eth. So it was only an issue because I had to spin the hardhat network separately (damn windows, won't happen anymore).
- Fixed environment variable code so it doesn't break if there is no "SNAPSHOT_BLOCKNUMBER" env variable (it will then take the latest block by default).

Also I have confirmed that the deployment of contracts with the COMM_KEY from the ENV variables work now that it has been merged to main.