### PR TITLE
chore: various improvements

### DIFF
--- a/.github/workflows/stateless-tests.yaml
+++ b/.github/workflows/stateless-tests.yaml
@@ -30,6 +30,8 @@ jobs:
       - run: npm install
       - run: echo /root/.local/bin >> $GITHUB_PATH
       - run: poetry install --quiet
+      - run: npx hardhat node &
+      - run: sleep 2
       - run: poetry run brownie test --network hardhat --stateful false
 
   store-artifacts:

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 .idea/
 .vscode/
 node_modules/
+.env

--- a/README.md
+++ b/README.md
@@ -56,17 +56,13 @@ To locally do a general check on both solidity and python code: (please ensure y
 yarn lint
 ```
 
-Format the solidity code using solhint+prettier:
+Format the solidity and python code:
 
 ```bash
-yarn format-sol
+yarn format
 ```
 
-Format the python code using black:
-
-```bash
-yarn format-py
-```
+To format them separately run `yarn format-sol` or `yarn format-py`
 
 ### Pre-commit hook
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
     "docgen": "npx solidity-docgen --solc-module solc-0.8 --templates=./docgen/ && npx markdownlint docs/ --config docgen/.markdownlint.json --fix",
     "lint": "npx solhint -w 0 'contracts/**/*.sol' && black . --check",
     "format-sol": "npx prettier --write 'contracts/**/*.sol'",
-    "format-py": "black ."
+    "format-py": "black .",
+    "format": "yarn format-sol && yarn format-py"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.0.0-rc3"


### PR DESCRIPTION
- Spin off external node also in the stateless tests.
- Add .env in .gitignore to avoid anyone from committing a .env file with their SEED by accident.
- Add ```yarn format``` to format both solidity and python at the same time. Updated README accordingly.