### PR TITLE
fix: fix consumeKeyNonce to external

### DIFF
--- a/.github/workflows/stateless-tests.yaml
+++ b/.github/workflows/stateless-tests.yaml
@@ -30,6 +30,8 @@ jobs:
       - run: npm install
       - run: echo /root/.local/bin >> $GITHUB_PATH
       - run: poetry install --quiet
+      - run: npx hardhat node &
+      - run: sleep 2
       - run: poetry run brownie test --network hardhat --stateful false
 
   store-artifacts:


### PR DESCRIPTION
Mark consumeKeyNonce as external. It is called from other contracts (FLIP, Vault, StakeManager) and when it's called by itself it's done through an external call due to the whitelisting. So there is no case where it's called internally.

Unfortunately, it doesn't seem to save any gas. There was that twitter thread about public functions copying all the data into memory but here it doesn't seem to be the case (maybe because the SigData is marked as calldata).

In any case, seems like good practice to change it to external.