### PR TITLE
feat: remove lowlevel call check in Deposit

### DIFF
--- a/contracts/Deposit.sol
+++ b/contracts/Deposit.sol
@@ -15,8 +15,7 @@ contract Deposit {
         vault = payable(msg.sender);
         if (address(token) == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE) {
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = msg.sender.call{value: address(this).balance}("");
-            require(success);
+            msg.sender.call{value: address(this).balance}("");
         } else {
             // Not checking the return value to avoid reverts for tokens with no return value.
             token.transfer(msg.sender, token.balanceOf(address(this)));
@@ -29,8 +28,7 @@ contract Deposit {
         // Slightly cheaper to use msg.sender instead of Vault.
         if (address(token) == 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE) {
             // solhint-disable-next-line avoid-low-level-calls
-            (bool success, ) = msg.sender.call{value: address(this).balance}("");
-            require(success);
+            msg.sender.call{value: address(this).balance}("");
         } else {
             // Not checking the return value to avoid reverts for tokens with no return value.
             token.transfer(msg.sender, token.balanceOf(address(this)));


### PR DESCRIPTION
I am not sure there is any value in checking the return boolean value when making a low level call from the Deposit contract to the Vault. I am aware that having the check is good practice and should be done 99% of the cases - I am just wondering if this might be that edgecase where it could make sense to remove it.

The call should never fail as it should always be a call to the Vault, which doesn't implement any logic on the receive side. And if for any reason that fails there is nothing that can be done anyway.

Gas-wise, it would save some gas on deploy, as the bytecode is being reduced, and a very slight reduction when fetch function calling. See below:

tests/unit/vault/test_fetchBatch.py::test_fetchBatch
   ├─ deployAndFetchBatch   -  avg (confirmed):  534938 
   └─ fetchBatch            - avg (confirmed):  113316

tests/unit/vault/test_fetchBatch.py::test_fetchBatch
   ├─ deployAndFetchBatch   - avg (confirmed):  532543
   └─ fetchBatch            -  avg (confirmed):  113296

Considering we will now be reusing addresses the deployment gas savings are not so important. And the gas savings on the fetchBatch are minimal, so I can see the argument for leaving the check as safeguard. However, I don't really think that check is adding anything.

What do you think? @cleanunicorn 