### PR TITLE
feat: safeguard setwhitelist and etherscan verific

### DIFF
--- a/contracts/StakeManager.sol
+++ b/contracts/StakeManager.sol
@@ -33,7 +33,7 @@ contract StakeManager is IStakeManager, AggKeyNonceConsumer, GovernanceCommunity
     /// @dev   Time after registerClaim required to wait before call to executeClaim
     uint48 public constant CLAIM_DELAY = 2 days;
     /// @dev   Deployer address that can call setFlip
-    address private immutable deployer;
+    address private immutable _deployer;
 
     // Defined in IStakeManager, just here for convenience
     // struct Claim {
@@ -47,7 +47,7 @@ contract StakeManager is IStakeManager, AggKeyNonceConsumer, GovernanceCommunity
 
     constructor(IKeyManager keyManager, uint256 minStake) AggKeyNonceConsumer(keyManager) {
         _minStake = minStake;
-        deployer = msg.sender;
+        _deployer = msg.sender;
     }
 
     /// @dev   Get the governor address from the KeyManager. This is called by the onlyGovernor
@@ -267,7 +267,7 @@ contract StakeManager is IStakeManager, AggKeyNonceConsumer, GovernanceCommunity
 
     /// @notice Ensure that the caller is the deployer address.
     modifier onlyDeployer() {
-        require(msg.sender == deployer, "Staking: not deployer");
+        require(msg.sender == _deployer, "Staking: not deployer");
         _;
     }
 }

--- a/scripts/deploy_contracts.py
+++ b/scripts/deploy_contracts.py
@@ -38,16 +38,16 @@ def main():
         print(f"  Deployer: {DEPLOYER}")
         print(f"  Safekeeper & GovKey: {os.environ['GOV_KEY']}")
         print(f"  Community Key: {os.environ['COMM_KEY']}")
-        # print(f"  Aggregate Key: {os.environ['AGG_KEY']}")
+        print(f"  Aggregate Key: {os.environ['AGG_KEY']}")
         print(f"  Genesis Stake: {os.environ['GENESIS_STAKE']}")
         print(f"  Num Genesis Validators: {os.environ['NUM_GENESIS_VALIDATORS']}")
         print(
             f"\nFLIP tokens will be minted to the Safekeeper account {os.environ['GOV_KEY']}"
         )
-        input(
-            "\n[WARNING] You are about to deploy to the mainnet with the parameters above. Continue? [y/N]"
+        user_input = input(
+            "\n[WARNING] You are about to deploy to the mainnet with the parameters above. Continue? [y/N] "
         )
-        if input != "y":
+        if user_input != "y":
             ## Gracefully exit the script with a message.
             sys.exit("Deployment cancelled by user")
 

--- a/tests/consts.py
+++ b/tests/consts.py
@@ -85,6 +85,7 @@ REV_MSG_KEYMANAGER_NONCE = "KeyManager: nonce already used"
 REV_MSG_DELAY = "KeyManager: not enough time"
 REV_MSG_KEYMANAGER_GOVERNOR = "KeyManager: not governor"
 REV_MSG_KEYMANAGER_NOT_COMMUNITY = "KeyManager: not Community Key"
+REV_MSG_KEYMANAGER_NOT_DEPLOYER = "KeyManager: not deployer"
 
 # -----SchnorrSECP256K1-----
 REV_MSG_PUB_KEY_X = "Public-key x >= HALF_Q"

--- a/tests/deploy.py
+++ b/tests/deploy.py
@@ -1,3 +1,4 @@
+import sys
 from os import environ
 from consts import *
 from web3.auto import w3
@@ -58,17 +59,33 @@ def deploy_initial_Chainflip_contracts(
         f"Deploying with NUM_GENESIS_VALIDATORS: {cf.numGenesisValidators}, GENESIS_STAKE: {cf.genesisStake}"
     )
 
+    publish_code = environment.get("PUBLISH_CODE") or False
+    if publish_code in ["true", "True", "TRUE"]:
+        user_input = input(
+            "\n[WARNING] You are about to publish the source code on Etherscan. Continue? [y/N] "
+        )
+        if user_input != "y":
+            sys.exit("Deployment cancelled by user")
+
+        # Etherscan API key required to publish source code - export ETHERSCAN_TOKEN=<API_KEY>
+        if "ETHERSCAN_TOKEN" not in environment:
+            raise Exception(f"Environment variable ETHERSCAN_TOKEN is not set")
+        publish_code = True
+    else:
+        # Force it to False in case the user has set it to an invalid value
+        publish_code = False
+
     # Deploy Key Manager contract
-    cf.keyManager = deployer.deploy(KeyManager, aggKey, cf.gov, cf.communityKey)
+    cf.keyManager = deployer.deploy(
+        KeyManager, aggKey, cf.gov, cf.communityKey, publish_source=publish_code
+    )
 
     # Deploy Vault contract
-    cf.vault = deployer.deploy(Vault, cf.keyManager)
+    cf.vault = deployer.deploy(Vault, cf.keyManager, publish_source=publish_code)
 
     # Deploy Stake Manager contract
     cf.stakeManager = deployer.deploy(
-        StakeManager,
-        cf.keyManager,
-        MIN_STAKE,
+        StakeManager, cf.keyManager, MIN_STAKE, publish_source=publish_code
     )
 
     # Deploy FLIP contract. Minting genesis validator FLIP to the Stake Manager.
@@ -81,9 +98,10 @@ def deploy_initial_Chainflip_contracts(
         cf.stakeManager.address,
         cf.gov,
         cf.keyManager,
+        publish_source=publish_code,
     )
 
-    cf.stakeManager.setFlip(cf.flip.address, {"from": deployer})
+    cf.stakeManager.setFlip(cf.flip, {"from": deployer})
 
     # All the deployer rights and tokens have been delegated to the governance key.
     cf.safekeeper = cf.gov
@@ -99,7 +117,7 @@ def deploy_set_Chainflip_contracts(
     cf = deploy_initial_Chainflip_contracts(
         deployer, KeyManager, Vault, StakeManager, FLIP, *args
     )
-    cf.whitelisted = [cf.vault.address, cf.stakeManager.address, cf.flip.address]
+    cf.whitelisted = [cf.vault, cf.stakeManager, cf.flip]
     cf.keyManager.setCanConsumeKeyNonce(cf.whitelisted, {"from": cf.deployer})
 
     return cf

--- a/tests/unit/keyManager/test_setCanConsumeNonce.py
+++ b/tests/unit/keyManager/test_setCanConsumeNonce.py
@@ -20,6 +20,23 @@ def test_setCanConsumeKeyNonce(a, KeyManager, Vault, StakeManager, FLIP, st_whit
     assert cf.keyManager.getNumberWhitelistedAddresses() == len(st_whitelist)
 
 
+@given(
+    st_sender=strategy("address"),
+    st_whitelist=strategy("address[]", unique=True),
+)
+def test_setCanConsumeKeyNonce_rev_sender(
+    a, KeyManager, Vault, StakeManager, FLIP, st_whitelist, st_sender
+):
+
+    cf = deploy_initial_Chainflip_contracts(a[9], KeyManager, Vault, StakeManager, FLIP)
+
+    if st_sender != cf.deployer:
+        with reverts(REV_MSG_KEYMANAGER_NOT_DEPLOYER):
+            cf.keyManager.setCanConsumeKeyNonce(st_whitelist, {"from": st_sender})
+    else:
+        cf.keyManager.setCanConsumeKeyNonce(st_whitelist, {"from": st_sender})
+
+
 def test_setCanConsumeKeyNonce_rev_duplicate(a, KeyManager, Vault, StakeManager, FLIP):
     cf = deploy_initial_Chainflip_contracts(a[9], KeyManager, Vault, StakeManager, FLIP)
     with reverts(REV_MSG_DUPLICATE):


### PR DESCRIPTION
Safeguard the setWhitelist to make mainnet deployment safer. Also, add Etherscan verification flag also for mainnet deployment.