### PR TITLE
chore: remove etherscan verification

### DIFF
--- a/tests/deploy.py
+++ b/tests/deploy.py
@@ -59,34 +59,14 @@ def deploy_initial_Chainflip_contracts(
         f"Deploying with NUM_GENESIS_VALIDATORS: {cf.numGenesisValidators}, GENESIS_STAKE: {cf.genesisStake}"
     )
 
-    publish_code = environment.get("PUBLISH_CODE") or False
-    if publish_code in ["true", "True", "TRUE"]:
-        user_input = input(
-            "\n[WARNING] You are about to publish the source code on Etherscan. Continue? [y/N] "
-        )
-        if user_input != "y":
-            sys.exit("Deployment cancelled by user")
-
-        # Etherscan API key required to publish source code - export ETHERSCAN_TOKEN=<API_KEY>
-        if "ETHERSCAN_TOKEN" not in environment:
-            raise Exception(f"Environment variable ETHERSCAN_TOKEN is not set")
-        publish_code = True
-    else:
-        # Force it to False in case the user has set it to an invalid value
-        publish_code = False
-
     # Deploy Key Manager contract
-    cf.keyManager = deployer.deploy(
-        KeyManager, aggKey, cf.gov, cf.communityKey, publish_source=publish_code
-    )
+    cf.keyManager = deployer.deploy(KeyManager, aggKey, cf.gov, cf.communityKey)
 
     # Deploy Vault contract
-    cf.vault = deployer.deploy(Vault, cf.keyManager, publish_source=publish_code)
+    cf.vault = deployer.deploy(Vault, cf.keyManager)
 
     # Deploy Stake Manager contract
-    cf.stakeManager = deployer.deploy(
-        StakeManager, cf.keyManager, MIN_STAKE, publish_source=publish_code
-    )
+    cf.stakeManager = deployer.deploy(StakeManager, cf.keyManager, MIN_STAKE)
 
     # Deploy FLIP contract. Minting genesis validator FLIP to the Stake Manager.
     # The rest of genesis FLIP will be minted to the governance address for safekeeping.
@@ -98,7 +78,6 @@ def deploy_initial_Chainflip_contracts(
         cf.stakeManager.address,
         cf.gov,
         cf.keyManager,
-        publish_source=publish_code,
     )
 
     cf.stakeManager.setFlip(cf.flip, {"from": deployer})


### PR DESCRIPTION
Remove etherscan logic from the scripts to avoid any accident. We will verify them separately via hardhat.