### PR TITLE
chore: make ICFReceiver more flexible

### DIFF
--- a/contracts/abstract/CFReceiver.sol
+++ b/contracts/abstract/CFReceiver.sol
@@ -94,8 +94,11 @@ abstract contract CFReceiver is ICFReceiver {
     //                                                          //
     //////////////////////////////////////////////////////////////
 
-    /// @dev Update Chainflip's Vault address
-    function updateCfVault(address _cfVault) external override onlyOwner {
+    /**
+     * @notice           Update Chanflip's Vault address.
+     * @param _cfVault    New Chainflip's Vault address.
+     */
+    function updateCfVault(address _cfVault) external onlyOwner {
         cfVault = _cfVault;
     }
 

--- a/contracts/interfaces/ICFReceiver.sol
+++ b/contracts/interfaces/ICFReceiver.sol
@@ -31,10 +31,4 @@ interface ICFReceiver {
      * @param message       The message sent on the source chain. This is a general purpose message.
      */
     function cfReceivexCall(uint32 srcChain, bytes calldata srcAddress, bytes calldata message) external;
-
-    /**
-     * @notice           Update Chanflip's Vault address.
-     * @param cfVault    New Chainflip's Vault address.
-     */
-    function updateCfVault(address cfVault) external;
 }


### PR DESCRIPTION
Remove `updateCfVault()` from `ICFReceive.sol` since it is not a requirement to have when integrating with Chainflip. They should be able to upgrade that, but this enforces it in an unnecessary way.