### PR TITLE
Chore/store deposit bytecode

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ jobs:
             cat build/contracts/$contract | jq .abi > ./$contract
           done <<< $CONTRACT_ARTIFACTS
           cat ./build/contracts/Deposit.json | jq .bytecode > Deposit_bytecode.json
-          zip abis.zip $(find . -maxdepth 1 -type f -name "*.json" -not -name "package*.json")
+          zip abis.zip $(find . -maxdepth 1 -type f -name "*.json" -not -name "package*.json" -not -path "./.*")
 
       - name: Store contract abis as Artefact
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
Improve the release tag script so it also stores the bytecode of the Deposit script. This is because the Deposit bytecode is used to derive ingress addresses. We should use this instead of a hardcoded bytecode that needs to be manually upgraded when something changes. It's not only the logic of the Deposit contract, but updating solc compiler version changes that.