### PR TITLE
Update Snapshot and Airdrop logic

### DIFF
--- a/scripts/airdrop.py
+++ b/scripts/airdrop.py
@@ -68,7 +68,7 @@ def main():
     if (not snapshotSuccessMessage + oldFlipSnapshotFilename in parsedLog) or (
         not os.path.exists(oldFlipSnapshotFilename)
     ):
-        # assert chain.id == 5, logging.error("Wrong chain. Should be running in goerli")
+        assert chain.id == 5 or chain.id == 31337, logging.error("Wrong chain. Should be running in goerli")
         printAndLog(
             "Old FLIP snapshot not taken previously. Snapshot Blocknumber set to "
             + str(snapshot_blocknumber)


### PR DESCRIPTION
Update the snapshot functionality of the airdrop script.

- Only a limited amount of log information can be pulled at a time, so I've broken down the rpc calls in chunks.
- The `balanceOf()` call is very slow and would take hours to complete if done for every account. Instead I manually calculate the balances by going through the entire FLIP ledger.

More modifications need to be done. We can probably get rid of the deployment of new contracts, since we will **always** do that separately. Then when it comes to the actual airdrop, we should mimic one and check how much time and eth it takes. If it's unreasonable we should just make a multisend contract.