### PR TITLE
chore: add bytecode check during deployment

### DIFF
--- a/.github/workflows/create-geth-image.yml
+++ b/.github/workflows/create-geth-image.yml
@@ -126,11 +126,6 @@ jobs:
       - run: yarn
       - run: poetry install
 
-      # Ensure that the Deposit's bytecode hasn't changed
-      - run: npx hardhat node --port 10997 &
-      - run: poetry run brownie networks add Ethereum hardhat-modif host=http://localhost:10997 chainid=31337
-      - run: poetry run brownie test tests/unit/vault/test_deployAndFetchBatch.py::test_getCreate2Addr --network hardhat-modif
-
       - name: Add the network
         run: poetry run brownie networks add Ethereum docker host=http://localhost:8545 chainid=10997
 

--- a/scripts/deploy_contracts.py
+++ b/scripts/deploy_contracts.py
@@ -16,6 +16,7 @@ from brownie import (
     DeployerContract,
     AddressChecker,
     CFTester,
+    Deposit,
 )
 from deploy import (
     deploy_Chainflip_contracts,
@@ -23,6 +24,7 @@ from deploy import (
     deploy_new_cfReceiver,
     deploy_contracts_secondary_evm,
 )
+from shared_tests import deposit_bytecode_test
 
 AUTONOMY_SEED = os.environ["SEED"]
 DEPLOY_ARTEFACT_ID = os.environ.get("DEPLOY_ARTEFACT_ID")
@@ -33,6 +35,9 @@ print(f"DEPLOYER = {deployer}")
 
 
 def main():
+    # Check the bytecode of the Deposit contract
+    deposit_bytecode_test(Deposit)
+
     if chain.id in arbitrum_networks:
         deploy_secondary_evm()
     else:

--- a/tests/shared_tests.py
+++ b/tests/shared_tests.py
@@ -294,3 +294,23 @@ def craftFetchParamsArray(depositAddresses, tokens):
     for index in range(length):
         args.append([depositAddresses[index], tokens[index]])
     return args
+
+
+# This is a test to catch when the Deposit bytecode changes. As of now this is machine
+# dependant and the results are for the github runners, so this test will fail locally.
+def deposit_bytecode_test(Deposit):
+    vault_address = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
+    flip_address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
+
+    depositAddr = getCreate2Addr(
+        vault_address,
+        cleanHexStrPad(web3.toHex(420696969)),
+        Deposit,
+        cleanHexStrPad(NATIVE_ADDR),
+    )
+    assert depositAddr == "0x311373270d730749FF22fd3c1F9836AA803Be47a"
+
+    depositAddr = getCreate2Addr(
+        vault_address, JUNK_HEX_PAD, Deposit, cleanHexStrPad(flip_address)
+    )
+    assert depositAddr == "0xe3477D1C61feDe43a5bbB5A7Fd40489225D18826"

--- a/tests/unit/vault/test_deployAndFetchBatch.py
+++ b/tests/unit/vault/test_deployAndFetchBatch.py
@@ -86,18 +86,4 @@ def test_deployAndFetchBatch_rev_deployed(cf, token):
 # This is a test to catch when the Deposit bytecode changes. As of now this is machine
 # dependant and the results are for the github runners, so this test will fail locally.
 def test_getCreate2Addr(Deposit):
-    vault_address = "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512"
-    flip_address = "0xCf7Ed3AccA5a467e9e704C703E8D87F634fB0Fc9"
-
-    depositAddr = getCreate2Addr(
-        vault_address,
-        cleanHexStrPad(web3.toHex(420696969)),
-        Deposit,
-        cleanHexStrPad(NATIVE_ADDR),
-    )
-    assert depositAddr == "0x311373270d730749FF22fd3c1F9836AA803Be47a"
-
-    depositAddr = getCreate2Addr(
-        vault_address, JUNK_HEX_PAD, Deposit, cleanHexStrPad(flip_address)
-    )
-    assert depositAddr == "0xe3477D1C61feDe43a5bbB5A7Fd40489225D18826"
+    deposit_bytecode_test(Deposit)


### PR DESCRIPTION
Closes: PRO-693

- Add bytecode test in `deploy_contracts`. Therefore it won't be possible to deploy with the incorrect bytecode.
- Removed check in `create-geth-image` as they will be checked in deploy_contracts itself.