### PR TITLE
Chore/add executor redemption

### DIFF
--- a/contracts/StateChainGateway.sol
+++ b/contracts/StateChainGateway.sol
@@ -46,6 +46,7 @@ contract StateChainGateway is IFlipIssuer, IStateChainGateway, AggKeyNonceConsum
     //     // into a single 256 bit slot
     //     uint48 startTime;
     //     uint48 expiryTime;
+    //     address executor;
     // }
 
     constructor(
@@ -155,7 +156,8 @@ contract StateChainGateway is IFlipIssuer, IStateChainGateway, AggKeyNonceConsum
         bytes32 nodeID,
         uint256 amount,
         address redeemAddress,
-        uint48 expiryTime
+        uint48 expiryTime,
+        address executor
     )
         external
         override
@@ -165,7 +167,7 @@ contract StateChainGateway is IFlipIssuer, IStateChainGateway, AggKeyNonceConsum
         nzAddr(redeemAddress)
         consumesKeyNonce(
             sigData,
-            keccak256(abi.encode(this.registerRedemption.selector, nodeID, amount, redeemAddress, expiryTime))
+            keccak256(abi.encode(this.registerRedemption.selector, nodeID, amount, redeemAddress, expiryTime, executor))
         )
     {
         require(
@@ -177,8 +179,8 @@ contract StateChainGateway is IFlipIssuer, IStateChainGateway, AggKeyNonceConsum
         uint48 startTime = uint48(block.timestamp) + REDEMPTION_DELAY;
         require(expiryTime > startTime, "Gateway: expiry time too soon");
 
-        _pendingRedemptions[nodeID] = Redemption(amount, redeemAddress, startTime, expiryTime);
-        emit RedemptionRegistered(nodeID, amount, redeemAddress, startTime, expiryTime);
+        _pendingRedemptions[nodeID] = Redemption(amount, redeemAddress, startTime, expiryTime, executor);
+        emit RedemptionRegistered(nodeID, amount, redeemAddress, startTime, expiryTime, executor);
     }
 
     /**
@@ -199,6 +201,9 @@ contract StateChainGateway is IFlipIssuer, IStateChainGateway, AggKeyNonceConsum
         delete _pendingRedemptions[nodeID];
 
         if (block.timestamp <= redemption.expiryTime) {
+            if (redemption.executor != address(0)) {
+                require(msg.sender == redemption.executor, "Gateway: not executor");
+            }
             emit RedemptionExecuted(nodeID, redemption.amount);
 
             // Send the tokens

--- a/contracts/StateChainGateway.sol
+++ b/contracts/StateChainGateway.sol
@@ -149,7 +149,8 @@ contract StateChainGateway is IFlipIssuer, IStateChainGateway, AggKeyNonceConsum
      * @param nodeID    The nodeID of the account redeeming the FLIP
      * @param amount    The amount of funds to be locked up
      * @param redeemAddress    The redeemAddress who will receive the FLIP
-     * @param expiryTime   The last valid timestamp that can execute this redemption (uint48)
+     * @param expiryTime  The last valid timestamp that can execute this redemption (uint48)
+     * @param executor    The address that can execute the redemption (zero address if anyone)
      */
     function registerRedemption(
         SigData calldata sigData,

--- a/contracts/echidna/contracts/StateChainGatewayEchidna.sol
+++ b/contracts/echidna/contracts/StateChainGatewayEchidna.sol
@@ -24,9 +24,10 @@ contract StateChainGatewayEchidna is IShared {
         bytes32 nodeID,
         uint256 amount,
         address redeemAddress,
-        uint48 expiryTime
+        uint48 expiryTime,
+        address executor
     ) external virtual {
-        sm.registerRedemption(sigData, nodeID, amount, redeemAddress, expiryTime);
+        sm.registerRedemption(sigData, nodeID, amount, redeemAddress, expiryTime, executor);
     }
 
     function executeRedemption(bytes32 nodeID) external virtual {

--- a/contracts/interfaces/IStateChainGateway.sol
+++ b/contracts/interfaces/IStateChainGateway.sol
@@ -17,7 +17,8 @@ interface IStateChainGateway is IGovernanceCommunityGuarded, IFlipIssuer, IAggKe
         uint256 amount,
         address indexed redeemAddress,
         uint48 startTime,
-        uint48 expiryTime
+        uint48 expiryTime,
+        address executor
     );
     event RedemptionExecuted(bytes32 indexed nodeID, uint256 amount);
     event RedemptionExpired(bytes32 indexed nodeID, uint256 amount);
@@ -33,6 +34,7 @@ interface IStateChainGateway is IGovernanceCommunityGuarded, IFlipIssuer, IAggKe
         // into a single 256 bit slot
         uint48 startTime;
         uint48 expiryTime;
+        address executor;
     }
 
     /**
@@ -69,7 +71,8 @@ interface IStateChainGateway is IGovernanceCommunityGuarded, IFlipIssuer, IAggKe
         bytes32 nodeID,
         uint256 amount,
         address redeemAddress,
-        uint48 expiryTime
+        uint48 expiryTime,
+        address executor
     ) external;
 
     /**

--- a/scripts/deploy_and.py
+++ b/scripts/deploy_and.py
@@ -81,9 +81,15 @@ def all_stateChainGateway_events():
 
     redemption_amount = int(MIN_FUNDING / 3)
     print(
-        f"\n💰 Alice registers a redemption for {redemption_amount} with nodeID {JUNK_INT}\n"
+        f"\n💰 Alice registers a redemption for {redemption_amount} with nodeID {JUNK_INT} and {ZERO_ADDR} executor\n"
     )
-    args = (JUNK_INT, redemption_amount, ALICE, chain.time() + (2 * REDEMPTION_DELAY))
+    args = (
+        JUNK_INT,
+        redemption_amount,
+        ALICE,
+        chain.time() + (2 * REDEMPTION_DELAY),
+        ZERO_ADDR,
+    )
 
     tx = signed_call_cf(
         cf, cf.stateChainGateway.registerRedemption, *args, sender=ALICE
@@ -96,7 +102,13 @@ def all_stateChainGateway_events():
     tx = cf.stateChainGateway.executeRedemption(JUNK_INT, {"from": ALICE})
     assert "RedemptionExecuted" in tx.events
 
-    args = (JUNK_INT, redemption_amount, ALICE, chain.time() + (2 * REDEMPTION_DELAY))
+    args = (
+        JUNK_INT,
+        redemption_amount,
+        ALICE,
+        chain.time() + (2 * REDEMPTION_DELAY),
+        ZERO_ADDR,
+    )
 
     tx = signed_call_cf(
         cf, cf.stateChainGateway.registerRedemption, *args, sender=ALICE

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -89,7 +89,7 @@ def fundedMin(cf):
 def redemptionRegistered(cf, fundedMin):
     _, amount = fundedMin
     expiryTime = getChainTime() + (2 * REDEMPTION_DELAY)
-    args = (JUNK_HEX, amount, cf.DENICE, expiryTime)
+    args = (JUNK_HEX, amount, cf.DENICE, expiryTime, ZERO_ADDR)
 
     sigData = AGG_SIGNER_1.getSigDataWithNonces(
         cf.keyManager, cf.stateChainGateway.registerRedemption, nonces, *args
@@ -100,7 +100,13 @@ def redemptionRegistered(cf, fundedMin):
         {"from": cf.ALICE},
     )
 
-    return tx, (amount, cf.DENICE, tx.timestamp + REDEMPTION_DELAY, expiryTime)
+    return tx, (
+        amount,
+        cf.DENICE,
+        tx.timestamp + REDEMPTION_DELAY,
+        expiryTime,
+        ZERO_ADDR,
+    )
 
 
 # Deploy a generic token

--- a/tests/consts.py
+++ b/tests/consts.py
@@ -121,7 +121,7 @@ MAX_TEST_FUND = 1 * 10**7 * E_18
 # 13292
 REDEMPTION_DELAY = 2 * DAY
 REDEMPTION_DELAY_TESTNETS = 2 * MINUTE
-NULL_CLAIM = (0, ZERO_ADDR, 0, 0)
+NULL_CLAIM = (0, ZERO_ADDR, 0, 0, ZERO_ADDR)
 
 REV_MSG_MIN_FUNDING = "Gateway: not enough funds"
 REV_MSG_CLAIM_EXISTS = "Gateway: a pending redemption exists"
@@ -130,6 +130,7 @@ REV_MSG_NOT_ON_TIME = "Gateway: early or already execd"
 REV_MSG_FLIP_ADDRESS = "Gateway: Flip address already set"
 REV_MSG_OLD_FLIP_SUPPLY_UPDATE = "Gateway: old FLIP supply update"
 REV_MSG_NOT_FLIP = "Gateway: wrong FLIP ref"
+REV_MSG_NOT_EXECUTOR = "Gateway: not executor"
 
 # -----Vault-----
 AGG_KEY_EMERGENCY_TIMEOUT = 3 * 24 * 60 * 60

--- a/tests/integration/keyManager/test_sig_verif.py
+++ b/tests/integration/keyManager/test_sig_verif.py
@@ -104,6 +104,7 @@ def test_sig_stateChainGateway(
         cf.flip.balanceOf(cf.stateChainGateway.address),
         cf.stateChainGateway.address,
         getChainTime() + (2 * REDEMPTION_DELAY),
+        ZERO_ADDR,
     ]
 
     # Generate original calldata for the call that is to be frontrunned
@@ -235,12 +236,7 @@ def test_sig_msgHash(cf, st_sender, st_new_govKey, st_address, st_chainId, st_am
         st_new_govKey,
     )
 
-    args = [
-        JUNK_HEX,
-        st_amount,
-        st_address,
-        getChainTime(),
-    ]
+    args = [JUNK_HEX, st_amount, st_address, getChainTime(), st_address]
     msgHash_verification(
         cf,
         cf.stateChainGateway.registerRedemption,

--- a/tests/integration/stateChainGateway/test_fund_redeem.py
+++ b/tests/integration/stateChainGateway/test_fund_redeem.py
@@ -28,6 +28,7 @@ def test_registerRedemption_fund_executeRedemption_fund_registerRedemption_execu
         redemptionAmount1,
         cf.DENICE,
         expiryTime1,
+        cf.ALICE,
     )
 
     # Redemptioning before enough time passed should revert
@@ -91,6 +92,7 @@ def test_registerRedemption_fund_executeRedemption_fund_registerRedemption_execu
         redemptionAmount2,
         cf.DENICE,
         expiryTime2,
+        ZERO_ADDR,
     )
 
     chain.sleep(REDEMPTION_DELAY + 5)

--- a/tests/integration/stateChainGateway/test_redemption_updateFlipSupply.py
+++ b/tests/integration/stateChainGateway/test_redemption_updateFlipSupply.py
@@ -17,6 +17,7 @@ def test_registerRedemption_updateFlipSupply_executeRedemption(cf, fundedMin):
         redemptionAmount,
         receiver,
         getChainTime() + (2 * REDEMPTION_DELAY),
+        cf.ALICE,
     )
 
     stateChainBlockNumber = 1

--- a/tests/integration/stateChainGateway/test_suspend_redemption.py
+++ b/tests/integration/stateChainGateway/test_suspend_redemption.py
@@ -99,5 +99,6 @@ def test_suspend_registerRedemption(cf, st_native_amount):
             st_native_amount,
             cf.DENICE,
             getChainTime() + REDEMPTION_DELAY,
+            ZERO_ADDR,
         )
         signed_call_cf(cf, cf.stateChainGateway.registerRedemption, *args)

--- a/tests/integration/upgradability/test_upgrade_contracts.py
+++ b/tests/integration/upgradability/test_upgrade_contracts.py
@@ -186,6 +186,7 @@ def test_upgrade_StateChainGateway(
         redemptionAmount,
         cf.DENICE,
         expiryTime,
+        cf.ALICE,
     )
 
     chain.sleep(REDEMPTION_DELAY)
@@ -211,6 +212,7 @@ def test_upgrade_StateChainGateway(
         redemptionAmount,
         newStateChainGateway,
         expiryTime,
+        ZERO_ADDR,
     )
 
     chain.sleep(REDEMPTION_DELAY)
@@ -230,6 +232,7 @@ def test_upgrade_StateChainGateway(
         redemptionAmount,
         cf.DENICE,
         getChainTime() + (REDEMPTION_DELAY * 2),
+        cf.ALICE,
     )
     chain.sleep(REDEMPTION_DELAY)
     newStateChainGateway.executeRedemption(nodeID, {"from": cf.ALICE})

--- a/tests/shared_tests.py
+++ b/tests/shared_tests.py
@@ -191,7 +191,7 @@ def fundTest(cf, prevTotal, nodeID, minFunding, tx, amount):
 # inputs through @given, so this is a common fcn that can be used for `test_redemption` and
 # similar tests that test specific desired values
 def registerRedemptionTest(
-    cf, stateChainGateway, nodeID, minFunding, amount, receiver, expiryTime
+    cf, stateChainGateway, nodeID, minFunding, amount, receiver, expiryTime, executor
 ):
     prevReceiverBal = cf.flip.balanceOf(receiver)
     prevStakeManBal = cf.flip.balanceOf(stateChainGateway)
@@ -203,6 +203,7 @@ def registerRedemptionTest(
         amount,
         receiver,
         expiryTime,
+        executor,
     )
 
     startTime = tx.timestamp + REDEMPTION_DELAY
@@ -212,6 +213,7 @@ def registerRedemptionTest(
         receiver,
         startTime,
         expiryTime,
+        executor,
     )
     assert tx.events["RedemptionRegistered"][0].values() == (
         nodeID,
@@ -219,6 +221,7 @@ def registerRedemptionTest(
         receiver,
         startTime,
         expiryTime,
+        executor,
     )
     # Check things that shouldn't have changed
     assert cf.flip.balanceOf(receiver) == prevReceiverBal

--- a/tests/stateful/test_stateChainGateway.py
+++ b/tests/stateful/test_stateChainGateway.py
@@ -151,6 +151,7 @@ def test_stateChainGateway(BaseStateMachine, state_machine, a, cfDeploy):
                 st_amount,
                 st_redeemAddress,
                 getChainTime() + st_expiry_time_diff,
+                ZERO_ADDR,
             )
             toLog = (*args, st_signer_agg, st_sender)
 

--- a/tests/unit/stateChainGateway/test_executeRedemption.py
+++ b/tests/unit/stateChainGateway/test_executeRedemption.py
@@ -19,32 +19,33 @@ def test_executeRedemption_empty(cf, st_nodeID, st_sender):
 @given(
     st_nodeID=strategy("uint", exclude=0),
     st_amount=strategy("uint", max_value=MIN_FUNDING * 2, exclude=0),
-    st_funder=strategy("address"),
+    st_redeem_address=strategy("address"),
     st_expiryTimeDiff=strategy(
         "uint", min_value=REDEMPTION_DELAY, max_value=2 * REDEMPTION_DELAY
     ),
     st_sleepTime=strategy("uint", min_value=5, max_value=3 * REDEMPTION_DELAY),
 )
 def test_executeRedemption_rand(
-    cf, st_nodeID, st_amount, st_funder, st_expiryTimeDiff, st_sleepTime
+    cf, st_nodeID, st_amount, st_redeem_address, st_expiryTimeDiff, st_sleepTime
 ):
     # Differences in the time.time() and chain time cause errors between runs when there's no actual issue
     if not (REDEMPTION_DELAY - 100 < st_expiryTimeDiff < REDEMPTION_DELAY + 100):
         st_nodeID = web3.toHex(st_nodeID)
         assert cf.stateChainGateway.getPendingRedemption(st_nodeID) == NULL_CLAIM
         scgStartBal = cf.flip.balanceOf(cf.stateChainGateway)
-        st_redeemAddress = cf.flip.balanceOf(st_funder)
+        st_redeemAddress = cf.flip.balanceOf(st_redeem_address)
 
         expiryTime = getChainTime() + st_expiryTimeDiff + 5
-        args = (st_nodeID, st_amount, st_funder, expiryTime)
+        args = (st_nodeID, st_amount, st_redeem_address, expiryTime, ZERO_ADDR)
 
         tx = signed_call_cf(cf, cf.stateChainGateway.registerRedemption, *args)
 
         assert cf.stateChainGateway.getPendingRedemption(st_nodeID) == (
             st_amount,
-            st_funder,
+            st_redeem_address,
             tx.timestamp + REDEMPTION_DELAY,
             expiryTime,
+            ZERO_ADDR,
         )
         assert cf.flip.balanceOf(cf.stateChainGateway) == scgStartBal
 
@@ -71,8 +72,8 @@ def test_executeRedemption_rand(
                 cf.flip.balanceOf(cf.stateChainGateway) == maxValidst_amount - st_amount
             )
             assert tx.events["RedemptionExecuted"][0].values() == [st_nodeID, st_amount]
-            assert cf.flip.balanceOf(st_funder) == st_redeemAddress + st_amount
-            assert tx.return_value == (st_funder, st_amount)
+            assert cf.flip.balanceOf(st_redeem_address) == st_redeemAddress + st_amount
+            assert tx.return_value == (st_redeem_address, st_amount)
 
             # Check things that shouldn't have changed
             assert cf.stateChainGateway.getMinimumFunding() == MIN_FUNDING
@@ -148,3 +149,40 @@ def test_executeRedemption_rev_suspended(cf, redemptionRegistered):
 
     with reverts(REV_MSG_GOV_SUSPENDED):
         cf.stateChainGateway.executeRedemption(JUNK_HEX, {"from": cf.ALICE})
+
+
+# Need to also register a redemption in this since the st_amounts sent etc depend on registerRedemption
+@given(
+    st_redeem_address=strategy("address"),
+    st_executor=strategy("address"),
+    st_executor_address=strategy("address"),
+)
+def test_executeRedemption_rev_executor(
+    cf, st_redeem_address, st_executor, st_executor_address
+):
+    # Different nodeID than the default registered Redemption
+    nodeId = web3.toHex(JUNK_INT + 1)
+
+    expiry_time = getChainTime() + (2 * REDEMPTION_DELAY)
+    args = (nodeId, JUNK_INT, st_redeem_address, expiry_time, st_executor_address)
+
+    tx = signed_call_cf(cf, cf.stateChainGateway.registerRedemption, *args)
+
+    assert cf.stateChainGateway.getPendingRedemption(nodeId) == (
+        JUNK_INT,
+        st_redeem_address,
+        tx.timestamp + REDEMPTION_DELAY,
+        expiry_time,
+        st_executor_address,
+    )
+
+    chain.sleep(REDEMPTION_DELAY)
+
+    if st_executor == st_executor_address:
+        tx = cf.stateChainGateway.executeRedemption(nodeId, {"from": st_executor})
+        assert cf.stateChainGateway.getPendingRedemption(nodeId) == NULL_CLAIM
+        assert tx.events["RedemptionExecuted"][0].values() == [nodeId, JUNK_INT]
+        assert tx.return_value == (st_redeem_address, JUNK_INT)
+    else:
+        with reverts(REV_MSG_NOT_EXECUTOR):
+            cf.stateChainGateway.executeRedemption(nodeId, {"from": st_executor})

--- a/tests/unit/stateChainGateway/test_executeRedemption.py
+++ b/tests/unit/stateChainGateway/test_executeRedemption.py
@@ -186,3 +186,7 @@ def test_executeRedemption_rev_executor(
     else:
         with reverts(REV_MSG_NOT_EXECUTOR):
             cf.stateChainGateway.executeRedemption(nodeId, {"from": st_executor})
+        chain.sleep(2 * REDEMPTION_DELAY)
+        tx = cf.stateChainGateway.executeRedemption(nodeId, {"from": st_executor})
+        assert tx.events["RedemptionExpired"][0].values() == [nodeId, JUNK_INT]
+        assert tx.return_value == (st_redeem_address, 0)

--- a/tests/unit/utils/test_deployers_constructor.py
+++ b/tests/unit/utils/test_deployers_constructor.py
@@ -173,6 +173,7 @@ def test_upgrader_constructor(
         flip.balanceOf(stateChainGateway.address),
         new_stateChainGateway.address,
         getChainTime() + (2 * REDEMPTION_DELAY),
+        st_sender,
     ]
 
     # Manually transfer FLIP funds.


### PR DESCRIPTION
Add redemption executor to allow for redemptions to only be executed by a particular address. This is a significant improvement for Liquidity stakers.