### PR TITLE
chore: increase egress gas and add transferFallback

### DIFF
--- a/tests/consts.py
+++ b/tests/consts.py
@@ -135,6 +135,7 @@ REV_MSG_NOT_FLIP = "Gateway: wrong FLIP ref"
 AGG_KEY_EMERGENCY_TIMEOUT = 3 * 24 * 60 * 60
 REV_MSG_VAULT_DELAY = "Vault: not enough time"
 REV_MSG_INSUFFICIENT_GAS = "Vault: insufficient gas"
+REV_MSG_TRANSFER_FALLBACK = "Vault: transfer fallback failed"
 
 # -----GovernanceCommunityGuarded-----
 REV_MSG_GOV_ENABLED_GUARD = "Governance: community guard enabled"

--- a/tests/stateful/test_upgradability.py
+++ b/tests/stateful/test_upgradability.py
@@ -207,6 +207,7 @@ def test_upgradability(
                 redemptionAmount,
                 newStateChainGateway,
                 expiryTime,
+                st_sender
             )
             signed_call_km(
                 self.km, self.scg.registerRedemption, *args, sender=st_sender

--- a/tests/stateful/test_upgradability.py
+++ b/tests/stateful/test_upgradability.py
@@ -207,7 +207,7 @@ def test_upgradability(
                 redemptionAmount,
                 newStateChainGateway,
                 expiryTime,
-                st_sender
+                st_sender,
             )
             signed_call_km(
                 self.km, self.scg.registerRedemption, *args, sender=st_sender

--- a/tests/unit/vault/test_transfer.py
+++ b/tests/unit/vault/test_transfer.py
@@ -24,6 +24,40 @@ def test_transfer_native_fails_recipient(cf, token):
     assert cf.ALICE.balance() == startBalRecipient
 
 
+# token doesn't have a fallback function for receiving native, so should fail
+def test_transferfallback_native_fails_recipient(cf, token):
+    cf.SAFEKEEPER.transfer(cf.vault, TEST_AMNT)
+
+    args = [[NATIVE_ADDR, token.address, TEST_AMNT]]
+    with reverts(REV_MSG_TRANSFER_FALLBACK):
+        signed_call_cf(cf, cf.vault.transferFallback, *args)
+
+
+def test_transfer_native_deposit_address(cf, Deposit):
+    tx = signed_call_cf(
+        cf,
+        cf.vault.deployAndFetchBatch,
+        [[JUNK_HEX, NATIVE_ADDR]],
+    )
+    depositAddr = getCreate2Addr(
+        cf.vault.address,
+        cleanHexStrPad(JUNK_HEX),
+        Deposit,
+        cleanHexStrPad(NATIVE_ADDR),
+    )
+    cf.SAFEKEEPER.transfer(cf.vault, TEST_AMNT)
+
+    startBalVault = cf.vault.balance()
+    startBalRecipient = web3.eth.get_balance(depositAddr)
+
+    args = [[NATIVE_ADDR, depositAddr, TEST_AMNT]]
+    tx = signed_call_cf(cf, cf.vault.transfer, *args)
+    assert "TransferNativeFailed" not in tx.events
+    # Transfer is succesfull but it will be funneled back to the vault
+    assert cf.vault.balance() == startBalVault
+    assert web3.eth.get_balance(depositAddr) == startBalRecipient
+
+
 # Trying to send native when there's none in the Vault
 def test_transfer_native_fails_not_enough_native(cf):
     startBalRecipient = cf.ALICE.balance()
@@ -35,43 +69,84 @@ def test_transfer_native_fails_not_enough_native(cf):
     assert cf.vault.balance() == 0
     assert cf.ALICE.balance() == startBalRecipient
 
+    with reverts(REV_MSG_TRANSFER_FALLBACK):
+        signed_call_cf(cf, cf.vault.transferFallback, *args)
+
 
 def test_transfer_token(cf, token):
+    transfer_token(cf, token, cf.vault.transfer)
+
+
+def test_transfer_fallback_token(cf, token):
+    transfer_token(cf, token, cf.vault.transferFallback)
+
+
+def transfer_token(cf, token, fcn):
     token.transfer(cf.vault, TEST_AMNT, {"from": cf.SAFEKEEPER})
 
     startBalVault = token.balanceOf(cf.vault)
     startBalRecipient = token.balanceOf(cf.ALICE)
 
     args = [[token, cf.ALICE, TEST_AMNT]]
-    signed_call_cf(cf, cf.vault.transfer, *args)
+    signed_call_cf(cf, fcn, *args)
 
     assert token.balanceOf(cf.vault) - startBalVault == -TEST_AMNT
     assert token.balanceOf(cf.ALICE) - startBalRecipient == TEST_AMNT
 
 
 def test_transfer_rev_tokenAddr(cf):
+    transfer_rev_tokenAddr(cf, cf.vault.transfer)
+
+
+def test_transferFallback_rev_tokenAddr(cf):
+    transfer_rev_tokenAddr(cf, cf.vault.transferFallback)
+
+
+def transfer_rev_tokenAddr(cf, fcn):
     with reverts(REV_MSG_NZ_ADDR):
         args = [[ZERO_ADDR, cf.ALICE, TEST_AMNT]]
-        signed_call_cf(cf, cf.vault.transfer, *args)
+        signed_call_cf(cf, fcn, *args)
 
 
 def test_transfer_rev_recipient(cf):
+    transfer_rev_tokenAddr(cf, cf.vault.transfer)
+
+
+def test_transferFallback_rev_recipient(cf):
+    transfer_rev_tokenAddr(cf, cf.vault.transferFallback)
+
+
+def transfer_rev_recipient(cf, fcn):
     with reverts(REV_MSG_NZ_ADDR):
         args = [[NATIVE_ADDR, ZERO_ADDR, TEST_AMNT]]
-        signed_call_cf(cf, cf.vault.transfer, *args)
+        signed_call_cf(cf, fcn, *args)
 
 
 def test_transfer_rev_amount(cf):
+    transfer_rev_amount(cf, cf.vault.transfer)
+
+
+def test_transferFallback_rev_amount(cf):
+    transfer_rev_amount(cf, cf.vault.transferFallback)
+
+
+def transfer_rev_amount(cf, fcn):
     with reverts(REV_MSG_NZ_UINT):
         args = [[NATIVE_ADDR, cf.ALICE, 0]]
-        signed_call_cf(cf, cf.vault.transfer, *args)
+        signed_call_cf(cf, fcn, *args)
 
 
 def test_transfer_rev_sig(cf):
+    transfer_rev_sig(cf, cf.vault.transfer)
+
+
+def test_transfer_rev_sig(cf):
+    transfer_rev_sig(cf, cf.vault.transferFallback)
+
+
+def transfer_rev_sig(cf, fcn):
     args = [[NATIVE_ADDR, cf.ALICE, TEST_AMNT]]
-    sigData = AGG_SIGNER_1.getSigDataWithNonces(
-        cf.keyManager, cf.vault.transfer, nonces, *args
-    )
+    sigData = AGG_SIGNER_1.getSigDataWithNonces(cf.keyManager, fcn, nonces, *args)
 
     sigData_modif = sigData[:]
     sigData_modif[0] += 1
@@ -102,8 +177,13 @@ def test_transfer_rev_usdt(cf, mockUSDT, utils):
     )
 
 
+def test_transferFallback_usdt(cf, mockUSDT):
+    args = [[mockUSDT.address, cf.ALICE, TEST_AMNT_USDC]]
+    with reverts():
+        signed_call_cf(cf, cf.vault.transferFallback, *args)
+
+
 def test_transfer_usdt(cf, mockUSDT):
-    print(mockUSDT.balanceOf(cf.SAFEKEEPER))
     mockUSDT.transfer(cf.vault, TEST_AMNT_USDC, {"from": cf.SAFEKEEPER})
     args = [[mockUSDT.address, cf.ALICE, TEST_AMNT_USDC]]
     iniBal_vault = mockUSDT.balanceOf(cf.vault)


### PR DESCRIPTION
- Increase egress gas to be able to transfer to our own deposit address.
- Add `transferFallback` function that egresses all the gas and reverts on transfer failure. This can be used when a transfer in a batch fails. Then a `transferFallback` can be signed so then the user to be able to egress with any gas amount. This way we do everything we can to not end up with funds stuck.