### PR TITLE
Feat vesting aggregation [WIP]

### DIFF
--- a/contracts/interfaces/IAddressHolder.sol
+++ b/contracts/interfaces/IAddressHolder.sol
@@ -8,9 +8,11 @@ interface IAddressHolder {
         address oldStFLIP,
         address oldStMinter,
         address oldStBurner,
+        address oldStAggregator,
         address newStFLIP,
         address newStMinter,
-        address newStBurner
+        address newStBurner,
+        address newStAggregator
     );
     event GovernorTransferred(address oldGovernor, address newGovernor);
 
@@ -22,7 +24,7 @@ interface IAddressHolder {
 
     function updateStateChainGateway(address _stateChainGateway) external;
 
-    function updateStakingAddresses(address _stMinter, address _stBurner, address _stFLIP) external;
+    function updateStakingAddresses(address _stMinter, address _stBurner, address _stFLIP, address _stAggregator) external;
 
     function transferGovernor(address _governor) external;
 

--- a/contracts/interfaces/IAddressHolder.sol
+++ b/contracts/interfaces/IAddressHolder.sol
@@ -38,5 +38,7 @@ interface IAddressHolder {
 
     function getUnstakingAddresses() external view returns (address, address);
 
+    function getAggregatorAddress() external view returns (address);
+
     function getGovernor() external view returns (address);
 }

--- a/contracts/mocks/MockStProvider.sol
+++ b/contracts/mocks/MockStProvider.sol
@@ -119,6 +119,10 @@ contract stFLIP is ERC20 {
         emit Burn(msg.sender, value, refundee);
         _burn(msg.sender, value);
     }
+
+    function mockSlash(address account, uint256 value) public {
+        _burn(account, value);
+    }
 }
 
 contract Aggregator is IAggregator {

--- a/contracts/mocks/MockStProvider.sol
+++ b/contracts/mocks/MockStProvider.sol
@@ -12,6 +12,21 @@ interface IBurner {
     function burn(address to, uint256 amount) external returns (uint256);
 }
 
+interface IAggregator {
+    function stakeAggregate(
+        uint256 amountTotal,
+        uint256 amountSwap,
+        uint256 minimumAmountSwapOut
+    ) external returns (uint256);
+
+    function unstakeAggregate(
+        uint256 amountInstantBurn,
+        uint256 amountBurn,
+        uint256 amountSwap,
+        uint256 minimumAmountSwapOut
+    ) external returns (uint256);
+}
+
 contract Minter is IMinter {
     stFLIP public stflip;
     IERC20 public flip;
@@ -34,6 +49,10 @@ contract Minter is IMinter {
     function _mint(address to, uint256 amount) internal {
         stflip.mint(to, amount);
         // emit Mint(to, amount);
+    }
+
+    function cheatMint(address to, uint256 amount) public {
+        _mint(to, amount);
     }
 }
 
@@ -69,6 +88,10 @@ contract Burner is IBurner {
         burns[burnId].completed = true;
         flip.transfer(burns[burnId].user, burns[burnId].amount);
     }
+
+    function cheatBurn(address to, uint256 amount) public {
+        flip.transfer(to, amount);
+    }
 }
 
 // solhint-disable-next-line contract-name-camelcase
@@ -95,5 +118,76 @@ contract stFLIP is ERC20 {
         require(msg.sender == burner, "only burner can burn");
         emit Burn(msg.sender, value, refundee);
         _burn(msg.sender, value);
+    }
+}
+
+contract Aggregator is IAggregator {
+    address public minter;
+    address public burner;
+
+    // if positive then stFLIP is at a discount. 10**18 = 1.0x
+    uint256 public mockAggregateMultiplier;
+    IERC20 flip;
+    stFLIP stflip;
+
+    constructor(address _minter, address _burner, address _stflip, address _flip) {
+        minter = _minter;
+        burner = _burner;
+        stflip = stFLIP(_stflip);
+        flip = IERC20(_flip);
+    }
+
+    function stakeAggregate(
+        uint256 amountTotal,
+        uint256 amountSwap,
+        uint256 minimumAmountSwapOut
+    ) external returns (uint256) {
+        flip.transferFrom(msg.sender, address(this), amountTotal);
+        uint256 swapReceived;
+        uint256 mintAmount = amountTotal - amountSwap;
+
+        if (amountSwap > 0) {
+            swapReceived = (amountSwap * mockAggregateMultiplier) / 10 ** 18;
+            Minter(minter).cheatMint(msg.sender, swapReceived);
+            flip.transfer(burner, amountSwap);
+        }
+
+        if (mintAmount > 0) {
+            Minter(minter).mint(msg.sender, mintAmount);
+        }
+
+        return mintAmount + swapReceived;
+    }
+
+    function unstakeAggregate(
+        uint256 amountInstantBurn,
+        uint256 amountBurn,
+        uint256 amountSwap,
+        uint256 minimumAmountSwapOut
+    ) external returns (uint256) {
+        uint256 total = amountInstantBurn + amountBurn + amountSwap;
+        uint256 swapReceived;
+
+        stflip.transferFrom(msg.sender, address(this), total);
+
+        if (amountInstantBurn > 0) {
+            uint256 instantBurnId = Burner(burner).burn(msg.sender, amountInstantBurn);
+            Burner(burner).redeem(instantBurnId);
+        }
+
+        if (amountBurn > 0) {
+            Burner(burner).burn(msg.sender, amountBurn);
+        }
+
+        if (amountSwap > 0) {
+            swapReceived = (amountSwap * (2 * 10 ** 18 - mockAggregateMultiplier)) / 10 ** 18;
+            Burner(burner).cheatBurn(msg.sender, swapReceived);
+        }
+
+        return amountInstantBurn + swapReceived;
+    }
+
+    function setMockMultiplier(uint256 multiplier) public {
+        mockAggregateMultiplier = multiplier;
     }
 }

--- a/contracts/utils/AddressHolder.sol
+++ b/contracts/utils/AddressHolder.sol
@@ -57,12 +57,14 @@ contract AddressHolder is IAddressHolder, Shared {
     function updateStakingAddresses(
         address _stMinter,
         address _stBurner,
-        address _stFLIP
+        address _stFLIP,
+        address _stAggregator
     ) external override onlyGovernor {
-        emit StakingAddressesUpdated(stMinter, stBurner, stFLIP, _stMinter, _stBurner, _stFLIP);
+        emit StakingAddressesUpdated(stMinter, stBurner, stFLIP, stAggregator, _stMinter, _stBurner, _stFLIP, _stAggregator);
         stMinter = _stMinter;
         stBurner = _stBurner;
         stFLIP = _stFLIP;
+        stAggregator = _stAggregator;
     }
 
     /// @dev    Allow the governor to transfer governance to a new address in case of need

--- a/contracts/utils/AddressHolder.sol
+++ b/contracts/utils/AddressHolder.sol
@@ -20,6 +20,7 @@ contract AddressHolder is IAddressHolder, Shared {
     address private stFLIP;
     address private stMinter;
     address private stBurner;
+    address private stAggregator;
 
     // @dev Allow stAddresses to be zero as they might not be known at the time of deployment
     constructor(
@@ -27,13 +28,15 @@ contract AddressHolder is IAddressHolder, Shared {
         address _stateChainGateway,
         address _stMinter,
         address _stBurner,
-        address _stFLIP
+        address _stFLIP,
+        address _stAggregator
     ) nzAddr(_governor) nzAddr(_stateChainGateway) {
         governor = _governor;
         stateChainGateway = _stateChainGateway;
         stMinter = _stMinter;
         stBurner = _stBurner;
         stFLIP = _stFLIP;
+        stAggregator = _stAggregator;
     }
 
     //////////////////////////////////////////////////////////////
@@ -86,6 +89,10 @@ contract AddressHolder is IAddressHolder, Shared {
 
     function getUnstakingAddresses() external view override returns (address, address) {
         return (stBurner, stFLIP);
+    }
+
+    function getAggregatorAddress() external view override returns (address) {
+        return stAggregator;
     }
 
     /// @dev    Getter function for the governor address

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -120,7 +120,7 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
         uint256 burnId = IBurner(stBurner).burn(address(this), amount);
         stTokenUnstaked += amount;
         return burnId;
-    } 
+    }
 
     /**
      * @notice Aggregates staking by purchasing stFLIP via Curve and minting via staking contract
@@ -129,9 +129,13 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
      * @dev `amountTotal - amountSwap` amount of FLIP will be minted. In order to determine the `amountSwap` amount, please call
      * `calculatePurchasable` with the correct parameters to determine the amount purchasable for a discount. For more information,
      * see `thunderhead-labs/stflip-contracts` repo. `minimumAmountSwapOut` should be derived by calling `calculateSwap` on the Curve pool
-     * and multiplying by the desired slippage tolerance. 
+     * and multiplying by the desired slippage tolerance.
      */
-    function aggregateStakeToStProvider(uint256 amountTotal, uint256 amountSwap, uint256 minimumAmountSwapOut) external onlyBeneficiary notRevoked {
+    function aggregateStakeToStProvider(
+        uint256 amountTotal,
+        uint256 amountSwap,
+        uint256 minimumAmountSwapOut
+    ) external onlyBeneficiary notRevoked {
         address stAggregator = addressHolder.getAggregatorAddress();
         (, address stFlip) = addressHolder.getUnstakingAddresses();
 
@@ -142,7 +146,10 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
 
         uint256 finalBalance = stFLIP(stFlip).balanceOf(address(this));
 
-        require(finalBalance >= initialBalance + amountTotal - amountSwap + minimumAmountSwapOut, "Vesting: did not receive enough stFLIP"); // additional safety precaution. trusted dependency, but lets assume adversarial mindset.
+        require(
+            finalBalance >= initialBalance + amountTotal - amountSwap + minimumAmountSwapOut,
+            "Vesting: did not receive enough stFLIP"
+        ); // additional safety precaution. trusted dependency, but lets assume adversarial mindset.
         stTokenStaked += received;
     }
 
@@ -153,7 +160,12 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
      * @param amountSwap the amount of stFLIP to swap for FLIP
      * @param minimumAmountSwapOut the minimum amount of FLIP to receive from the swap
      */
-    function aggregateUnstakeToStProvider(uint256 amountInstantBurn, uint256 amountBurn, uint256 amountSwap, uint256 minimumAmountSwapOut) external onlyBeneficiary notRevoked {
+    function aggregateUnstakeToStProvider(
+        uint256 amountInstantBurn,
+        uint256 amountBurn,
+        uint256 amountSwap,
+        uint256 minimumAmountSwapOut
+    ) external onlyBeneficiary notRevoked {
         address stAggregator = addressHolder.getAggregatorAddress();
         (address burner, address stFlip) = addressHolder.getUnstakingAddresses();
 
@@ -165,7 +177,10 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
 
         uint256 finalBalance = FLIP.balanceOf(address(this));
 
-        require(finalBalance >= initialBalance + amountInstantBurn + minimumAmountSwapOut, "Vesting: did not receive enough FLIP"); // additional safety precaution. trusted dependency, but lets assume adversarial mindset.
+        require(
+            finalBalance >= initialBalance + amountInstantBurn + minimumAmountSwapOut,
+            "Vesting: did not receive enough FLIP"
+        ); // additional safety precaution. trusted dependency, but lets assume adversarial mindset.
         stTokenUnstaked += total;
     }
 
@@ -174,7 +189,7 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
      * @param recipient_ the address to send the rewards to. If 0x0, then the beneficiary is used.
      * @param amount_ the amount of rewards to claim. If greater than `totalRewards`, then all rewards are claimed.
      * @dev `stTokenCounter` updates after staking/unstaking operation to keep track of the st token principle. Any amount above the
-     * principle is considered rewards and thus can be claimed by the beneficiary. 
+     * principle is considered rewards and thus can be claimed by the beneficiary.
      */
     function claimStProviderRewards(address recipient_, uint256 amount_) external onlyBeneficiary notRevoked {
         (, address stFlip) = addressHolder.getUnstakingAddresses();

--- a/contracts/utils/TokenVestingStaking.sol
+++ b/contracts/utils/TokenVestingStaking.sol
@@ -190,10 +190,34 @@ contract TokenVestingStaking is ITokenVestingStaking, Shared {
      * @param amount_ the amount of rewards to claim. If greater than `totalRewards`, then all rewards are claimed.
      * @dev `stTokenCounter` updates after staking/unstaking operation to keep track of the st token principle. Any amount above the
      * principle is considered rewards and thus can be claimed by the beneficiary.
+     * 
+     * Claim rewards flow possibilities
+     * 1. increment stake (staked 100, unstaked 0, balance 100)
+     * 2. earn rewards    (staked 100, unstaked 0, balance 103)
+     * 3. claim rewards   (staked 100, unstaked 0, balance 100) 103 + 0 - 100 = 3
+     * 4. receive 3 stflip
+     * 
+     * 1. stake            (staked 100, unstaked 0, balance 100)
+     * 2. earn rewards     (staked 100, unstaked 0, balance 103)
+     * 3. unstake all      (staked 100, unstaked 103, balance 0)
+     * 4. claim underflows (staked 100, unstaked 103, balance 0) 0 + 103 - 100 = 3
+     * 5. Need to have stflip to claim
+
+     * 1. stake            (staked 100, unstaked 0, balance 100)
+     * 2. get slashed      (staked 100, unstaked 0, balance 95)
+     * 3. unstake all      (staked 100, unstaked 0, balance 95)
+     * 4. claim underflows (staked 100, unstaked 0, balance 95) 95 + 0 - 100 = -5
+     * 5. must earn 5 stflip first before earning claimable rewards
+     * 
+     * 1. stake            (staked 100, unstaked 0, balance 100)
+     * 2. earn rewards     (staked 100, unstaked 0, balance 103)
+     * 3. unstake half     (staked 50, unstaked 53, balance 50)
+     * 4. claim rewards   (staked 50, unstaked 53, balance 50) 50 + 53 - 50 = 3
+     * 5. Receive 3 stflip
      */
     function claimStProviderRewards(address recipient_, uint256 amount_) external onlyBeneficiary notRevoked {
         (, address stFlip) = addressHolder.getUnstakingAddresses();
-        uint256 totalRewards = stFLIP(stFlip).balanceOf(address(this)) - stTokenStaked + stTokenUnstaked;
+        uint256 totalRewards = stFLIP(stFlip).balanceOf(address(this)) + stTokenUnstaked - stTokenStaked;
 
         uint256 amount = amount_ > totalRewards ? totalRewards : amount_;
         address recipient = recipient_ == address(0) ? beneficiary : recipient_;

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -141,8 +141,7 @@ def maths(addrs, MockMaths):
 
 
 @pytest.fixture(scope="module")
-def mockStProvider(cf, addrs, Minter, Burner, stFLIP):
-
+def mockStProvider(cf, addrs, Minter, Burner, stFLIP, Aggregator):
     stFlip = addrs.DEPLOYER.deploy(stFLIP)
 
     burner = addrs.DEPLOYER.deploy(Burner, stFlip.address, cf.flip)
@@ -155,14 +154,18 @@ def mockStProvider(cf, addrs, Minter, Burner, stFLIP):
         Minter, stFlip.address, cf.flip.address, staking_address
     )
 
+    aggregator = addrs.DEPLOYER.deploy(
+        Aggregator, minter.address, burner.address, stFlip.address, cf.flip.address
+    )
+
     stFlip.initialize(minter.address, burner.address)
 
-    return stFlip, minter, burner, staking_address
+    return stFlip, minter, burner, staking_address, aggregator
 
 
 @pytest.fixture(scope="module")
 def addressHolder(cf, addrs, AddressHolder, mockStProvider):
-    stFLIP, minter, burner, _ = mockStProvider
+    stFLIP, minter, burner, _, aggregator = mockStProvider
 
     return deploy_addressHolder(
         addrs.DEPLOYER,
@@ -172,12 +175,12 @@ def addressHolder(cf, addrs, AddressHolder, mockStProvider):
         minter.address,
         burner.address,
         stFLIP.address,
+        aggregator.address,
     )
 
 
 @pytest.fixture(scope="module")
 def tokenVestingNoStaking(addrs, cf, TokenVestingNoStaking):
-
     # This was hardcoded to a timestamp, but ganache uses real-time when we run
     # the tests, so we should use relative values instead of absolute ones
     start = getChainTime()

--- a/tests/deploy.py
+++ b/tests/deploy.py
@@ -17,7 +17,6 @@ def deploy_Chainflip_contracts(
     AddressChecker,
     *args,
 ):
-
     # Set the priority fee for all transactions and the required number of confirmations.
     required_confs = transaction_params()
 
@@ -245,6 +244,7 @@ def deploy_addressHolder(
     stMinter_address,
     stBurner_address,
     stFLIP_address,
+    aggregator_address,
 ):
     # Set the priority fee for all transactions and the required number of confirmations.
     required_confs = transaction_params()
@@ -255,6 +255,7 @@ def deploy_addressHolder(
         stMinter_address,
         stBurner_address,
         stFLIP_address,
+        aggregator_address,
         {"from": deployer, "required_confs": required_confs},
     )
 

--- a/tests/token_vesting/addressHolder/test_addressHolder.py
+++ b/tests/token_vesting/addressHolder/test_addressHolder.py
@@ -28,7 +28,7 @@ def test_reference_constructor(addrs, cf, AddressHolder):
 
     # We allow zero addresses to be passed as staking provider references
     addressHolder = addrs.DEPLOYER.deploy(
-        AddressHolder, addrs.DEPLOYER, NON_ZERO_ADDR, ZERO_ADDR, ZERO_ADDR, ZERO_ADDR
+        AddressHolder, addrs.DEPLOYER, NON_ZERO_ADDR, ZERO_ADDR, ZERO_ADDR, ZERO_ADDR, ZERO_ADDR
     )
     assert addressHolder.getGovernor() == addrs.DEPLOYER
     assert addressHolder.getStateChainGateway() == NON_ZERO_ADDR
@@ -101,12 +101,14 @@ def test_reference_updateStakingAddresses(addrs, addressHolder):
     oldAddresses = (
         addressHolder.getStakingAddress(),
         *addressHolder.getUnstakingAddresses(),
+        addressHolder.getAggregatorAddress()
     )
     for addresses in [
-        (ZERO_ADDR, NON_ZERO_ADDR, NON_ZERO_ADDR),
-        (NON_ZERO_ADDR, ZERO_ADDR, NON_ZERO_ADDR),
-        (NON_ZERO_ADDR, NON_ZERO_ADDR, ZERO_ADDR),
-        (ZERO_ADDR, ZERO_ADDR, ZERO_ADDR),
+        (ZERO_ADDR, NON_ZERO_ADDR, NON_ZERO_ADDR, NON_ZERO_ADDR),
+        (NON_ZERO_ADDR, ZERO_ADDR, NON_ZERO_ADDR, NON_ZERO_ADDR),
+        (NON_ZERO_ADDR, NON_ZERO_ADDR, ZERO_ADDR, NON_ZERO_ADDR),
+        (NON_ZERO_ADDR, NON_ZERO_ADDR, NON_ZERO_ADDR, ZERO_ADDR),
+        (ZERO_ADDR, ZERO_ADDR, ZERO_ADDR, ZERO_ADDR),
     ]:
         tx = addressHolder.updateStakingAddresses(*addresses, {"from": addrs.DEPLOYER})
         assert tx.events["StakingAddressesUpdated"][0].values() == (
@@ -115,4 +117,6 @@ def test_reference_updateStakingAddresses(addrs, addressHolder):
         )
         assert addressHolder.getStakingAddress() == addresses[0]
         assert addressHolder.getUnstakingAddresses() == [addresses[1], addresses[2]]
+        assert addressHolder.getAggregatorAddress() == addresses[3]
+
         oldAddresses = addresses

--- a/tests/token_vesting/addressHolder/test_addressHolder.py
+++ b/tests/token_vesting/addressHolder/test_addressHolder.py
@@ -12,6 +12,7 @@ def test_reference_constructor(addrs, cf, AddressHolder):
             NON_ZERO_ADDR,
             NON_ZERO_ADDR,
             NON_ZERO_ADDR,
+            NON_ZERO_ADDR
         )
 
     with reverts(REV_MSG_NZ_ADDR):
@@ -22,6 +23,7 @@ def test_reference_constructor(addrs, cf, AddressHolder):
             NON_ZERO_ADDR,
             NON_ZERO_ADDR,
             NON_ZERO_ADDR,
+            NON_ZERO_ADDR
         )
 
     # We allow zero addresses to be passed as staking provider references

--- a/tests/token_vesting/constructor/test_tokenVesting_constructor.py
+++ b/tests/token_vesting/constructor/test_tokenVesting_constructor.py
@@ -11,7 +11,6 @@ end = start + YEAR
 def test_tokenVesting_constructor_cliff(
     addrs, TokenVestingNoStaking, TokenVestingStaking, cf, addressHolder
 ):
-
     tv = addrs.DEPLOYER.deploy(
         TokenVestingNoStaking,
         addrs.BENEFICIARY,
@@ -162,7 +161,6 @@ def test_tokenVesting_constructor_rev_stateChainGateway(addrs, TokenVestingStaki
 
 
 def test_tokenVesting_constructor_rev_eoa(addrs, TokenVestingStaking):
-
     tv = addrs.DEPLOYER.deploy(
         TokenVestingStaking,
         addrs.BENEFICIARY,

--- a/tests/token_vesting/funding/test_funding.py
+++ b/tests/token_vesting/funding/test_funding.py
@@ -9,7 +9,6 @@ import time
     st_amount=strategy("uint256", max_value=MAX_TEST_FUND * 2),
 )
 def test_fundStateChainAccount(addrs, tokenVestingStaking, st_nodeID, st_amount, cf):
-
     tv, _, _ = tokenVestingStaking
 
     st_nodeID = web3.toHex(st_nodeID)
@@ -40,7 +39,6 @@ def test_fund_rev_beneficiary(a, addrs, tokenVestingStaking):
 
 
 def test_fund_rev_beneficiary(addrs, TokenVestingStaking, addressHolder, cf):
-
     tv = addrs.DEPLOYER.deploy(
         TokenVestingStaking,
         addrs.BENEFICIARY,

--- a/tests/token_vesting/release/test_release_nostaking.py
+++ b/tests/token_vesting/release/test_release_nostaking.py
@@ -86,7 +86,6 @@ def test_consecutive_releases_after_cliff(addrs, cf, tokenVestingNoStaking, math
     ]
 
     for timestamp in timestamps:
-
         chain.sleep(timestamp - previousTimestamp)
         print(timestamp)
         tx = tv.release(cf.flip, {"from": addrs.BENEFICIARY})

--- a/tests/token_vesting/release/test_release_staking.py
+++ b/tests/token_vesting/release/test_release_staking.py
@@ -87,7 +87,6 @@ def test_consecutive_releases_after_cliff(
     # In staking  conctrracts cliff == end
     # No amount can be released until we reach the cliff == end where it is all releasable
     for timestamp in timestamps:
-
         chain.sleep(timestamp - previousTimestamp)
         if getChainTime() < end:
             release_revert(tv, cf, addrs.BENEFICIARY)

--- a/tests/token_vesting/stakeStProvider/test_stAggregation.py
+++ b/tests/token_vesting/stakeStProvider/test_stAggregation.py
@@ -1,0 +1,128 @@
+from consts import *
+from brownie import reverts
+from shared_tests_tokenVesting import *
+
+
+def test_stakeAggregateStProvider(addrs, tokenVestingStaking, cf, mockStProvider):
+    tv, _, total = tokenVestingStaking
+    stFLIP, _, _, staking_address, aggregator = mockStProvider
+
+    mockMultiplier = 11 * 10**17
+    expectedReceived = int(
+        int(int(total) * int(mockMultiplier)) // 10**18
+    )  # i was getting weird rounding issues. not sure what the best practice is here in brownie
+    aggregator.setMockMultiplier(mockMultiplier)
+    print(
+        "balances",
+        cf.flip.balanceOf(tv),
+        stFLIP.balanceOf(tv),
+        cf.flip.balanceOf(staking_address),
+        stFLIP.balanceOf(staking_address),
+    )
+
+    assert cf.flip.balanceOf(tv) == total
+    assert stFLIP.balanceOf(tv) == 0
+    assert cf.flip.balanceOf(staking_address) == 0
+    assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenStaked() == 0
+    assert tv.stTokenUnstaked() == 0
+
+    tv.aggregateStakeToStProvider(total, total, 0, {"from": addrs.BENEFICIARY})
+
+    print(
+        "balances",
+        cf.flip.balanceOf(tv),
+        stFLIP.balanceOf(tv),
+        cf.flip.balanceOf(staking_address),
+        stFLIP.balanceOf(staking_address),
+    )
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == expectedReceived
+    assert cf.flip.balanceOf(staking_address) == total
+    assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenStaked() == expectedReceived
+    assert tv.stTokenUnstaked() == 0
+
+
+def test_unstakeAggregateStProvider(addrs, tokenVestingStaking, cf, mockStProvider):
+    tv, _, total = tokenVestingStaking
+    stFLIP, _, _, staking_address, aggregator = mockStProvider
+
+    mockMultiplier = 11 * 10**17
+    expectedReceived = int(
+        int(int(total) * (2 * 10**18 - int(mockMultiplier))) // 10**18
+    )  # i was getting weird rounding issues. not sure what the best practice is here in brownie
+    aggregator.setMockMultiplier(mockMultiplier)
+
+    tv.stakeToStProvider(total, {"from": addrs.BENEFICIARY})
+
+    print(
+        "balances",
+        cf.flip.balanceOf(tv),
+        stFLIP.balanceOf(tv),
+        cf.flip.balanceOf(staking_address),
+        stFLIP.balanceOf(staking_address),
+    )
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total
+    assert cf.flip.balanceOf(staking_address) == total
+    assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+    tv.aggregateUnstakeToStProvider(0, 0, total, 0, {"from": addrs.BENEFICIARY})
+
+    print(
+        "balances",
+        cf.flip.balanceOf(tv),
+        stFLIP.balanceOf(tv),
+        cf.flip.balanceOf(staking_address),
+        stFLIP.balanceOf(staking_address),
+    )
+
+    assert cf.flip.balanceOf(tv) == expectedReceived
+    assert stFLIP.balanceOf(tv) == 0
+    assert cf.flip.balanceOf(staking_address) == total - expectedReceived
+    assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == total
+
+
+def test_stProviderClaimRewards(addrs, tokenVestingStaking, cf, mockStProvider):
+    tv, _, total = tokenVestingStaking
+    stFLIP, minter, _, staking_address, aggregator = mockStProvider
+    reward_amount = 100 * 10**18
+
+    cf.flip.approve(minter, 2**256 - 1, {"from": addrs.DEPLOYER})
+    minter.mint(addrs.DEPLOYER, reward_amount, {"from": addrs.DEPLOYER})
+
+    assert cf.flip.balanceOf(tv) == total
+    assert stFLIP.balanceOf(tv) == 0
+    assert tv.stTokenStaked() == 0
+    assert tv.stTokenUnstaked() == 0
+
+    tv.stakeToStProvider(total, {"from": addrs.BENEFICIARY})
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+    stFLIP.transfer(tv, reward_amount, {"from": addrs.DEPLOYER})  # earn rewards
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total + reward_amount
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+    tv.claimStProviderRewards(
+        addrs.BENEFICIARY, reward_amount, {"from": addrs.BENEFICIARY}
+    )
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+    assert stFLIP.balanceOf(addrs.BENEFICIARY) == reward_amount

--- a/tests/token_vesting/stakeStProvider/test_stAggregation.py
+++ b/tests/token_vesting/stakeStProvider/test_stAggregation.py
@@ -126,3 +126,83 @@ def test_stProviderClaimRewards(addrs, tokenVestingStaking, cf, mockStProvider):
     assert tv.stTokenStaked() == total
     assert tv.stTokenUnstaked() == 0
     assert stFLIP.balanceOf(addrs.BENEFICIARY) == reward_amount
+
+def test_stProviderClaimRewardsInsufficientStflip(addrs, tokenVestingStaking, cf, mockStProvider):
+    tv, _, total = tokenVestingStaking
+    stFLIP, minter, _, staking_address, aggregator = mockStProvider
+    reward_amount = 100 * 10**18
+
+    cf.flip.approve(minter, 2**256 - 1, {"from": addrs.DEPLOYER})
+    minter.mint(addrs.DEPLOYER, reward_amount, {"from": addrs.DEPLOYER})
+
+    assert cf.flip.balanceOf(tv) == total
+    assert stFLIP.balanceOf(tv) == 0
+    assert tv.stTokenStaked() == 0
+    assert tv.stTokenUnstaked() == 0
+
+    tv.stakeToStProvider(total, {"from": addrs.BENEFICIARY})
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+    stFLIP.transfer(tv, reward_amount, {"from": addrs.DEPLOYER})  # earn rewards
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total + reward_amount
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+
+    tv.unstakeFromStProvider(total + reward_amount, {"from": addrs.BENEFICIARY})
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == 0
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == total + reward_amount
+
+
+    with reverts(REV_MSG_ERC20_EXCEED_BAL):
+        tv.claimStProviderRewards(
+            addrs.BENEFICIARY, reward_amount, {"from": addrs.BENEFICIARY}
+        )
+
+
+def test_stProviderClaimRewardsInsufficientStflip(addrs, tokenVestingStaking, cf, mockStProvider):
+    tv, _, total = tokenVestingStaking
+    stFLIP, minter, _, staking_address, aggregator = mockStProvider
+    slash_amount = 100 * 10**18
+
+    assert cf.flip.balanceOf(tv) == total
+    assert stFLIP.balanceOf(tv) == 0
+    assert tv.stTokenStaked() == 0
+    assert tv.stTokenUnstaked() == 0
+
+    tv.stakeToStProvider(total, {"from": addrs.BENEFICIARY})
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+    stFLIP.mockSlash(tv, slash_amount, {"from": addrs.DEPLOYER})  # earn rewards
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == total - slash_amount
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == 0
+
+
+    tv.unstakeFromStProvider(total - slash_amount, {"from": addrs.BENEFICIARY})
+
+    assert cf.flip.balanceOf(tv) == 0
+    assert stFLIP.balanceOf(tv) == 0
+    assert tv.stTokenStaked() == total
+    assert tv.stTokenUnstaked() == total - slash_amount
+
+
+    with reverts(REV_MSG_INTEGER_OVERFLOW):
+        tv.claimStProviderRewards(
+            addrs.BENEFICIARY, 2**256 - 1, {"from": addrs.BENEFICIARY}
+        )

--- a/tests/token_vesting/stakeStProvider/test_stProvider.py
+++ b/tests/token_vesting/stakeStProvider/test_stProvider.py
@@ -5,17 +5,22 @@ from shared_tests_tokenVesting import *
 
 def test_stakeToStProvider(addrs, tokenVestingStaking, cf, mockStProvider):
     tv, _, total = tokenVestingStaking
-    stFLIP, _, _, staking_address = mockStProvider
+    stFLIP, _, _, staking_address, _ = mockStProvider
 
     assert cf.flip.balanceOf(tv) == total
     assert stFLIP.balanceOf(tv) == 0
     assert cf.flip.balanceOf(staking_address) == 0
     assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenUnstaked() == 0
+    assert tv.stTokenStaked() == 0
+
     tv.stakeToStProvider(total, {"from": addrs.BENEFICIARY})
     assert cf.flip.balanceOf(tv) == 0
     assert stFLIP.balanceOf(tv) == total
     assert cf.flip.balanceOf(staking_address) == total
     assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenUnstaked() == 0
+    assert tv.stTokenStaked() == total
 
 
 def test_stake_unstake_rev_sender(addrs, tokenVestingStaking):
@@ -45,7 +50,7 @@ def test_stake_rev_revoked(addrs, tokenVestingStaking, cf):
 
 def test_unstake_rev_revoked(addrs, tokenVestingStaking, mockStProvider):
     tv, _, _ = tokenVestingStaking
-    stFLIP, _, _, _ = mockStProvider
+    stFLIP, _, _, _, _ = mockStProvider
 
     tv.revoke(stFLIP, {"from": addrs.REVOKER})
 
@@ -55,7 +60,7 @@ def test_unstake_rev_revoked(addrs, tokenVestingStaking, mockStProvider):
 
 def test_unstakeFromStProvider(addrs, tokenVestingStaking, cf, mockStProvider):
     tv, _, total = tokenVestingStaking
-    stFLIP, _, burner, staking_address = mockStProvider
+    stFLIP, _, burner, staking_address, _ = mockStProvider
 
     test_stakeToStProvider(addrs, tokenVestingStaking, cf, mockStProvider)
 
@@ -73,3 +78,5 @@ def test_unstakeFromStProvider(addrs, tokenVestingStaking, cf, mockStProvider):
     assert stFLIP.balanceOf(tv) == 0
     assert cf.flip.balanceOf(staking_address) == 0
     assert stFLIP.balanceOf(staking_address) == 0
+    assert tv.stTokenUnstaked() == total
+    assert tv.stTokenStaked() == total


### PR DESCRIPTION
# Added Features
`uint256 stTokenStaked`
Value to be incremented by the quantity of incoming stFLIP after every staking operation. 

`uint256 stTokenUnstaked`
Value to be incremented by the quantity of outgoing stFLIP after every unstaking operation. We must have this in a separate value since a dynamic principal counter would overflow in the case that a user unstakes their entire principal + rewards. 

`function aggregateStakeToStProvider( uint256 amountTotal, uint256 amountSwap, uint256 minimumAmountSwapOut )`
Calls `stakeAggregate` on the StakedFlip `Aggregator` with the params given. The vesting contract performs a sanity check to ensure that it has received enough stFLIP. Increments `stTokenStaked` with `amountReceived`.

`function aggregateUnstakeToStProvider( uint256 amountInstantBurn, uint256 amountBurn, uint256 amountSwap, uint256 minimumAmountSwapOut )`
Calls `unstakeAggregate` on the StakedFlip `Aggregator` with the params given. The vesting contract performs a sanity check to ensure that it receives enough FLIP. Increments `stTokenUnstaked` with `amountInstantBurn + amountBurn + amountSwap`.

`function claimStProviderRewards(address recipient_, uint256 amount_)`
Allows a user to claim stFLIP rewards. `claimableRewards = stflip.balanceOf(this) + stTokenUnstaked - stTokenStaked`. This keeps track of the amount of stFLIP rewards the user can claim at a given moment. It is possible that a user can have `claimableRewards > 0` and not be able to claim stFLIP because of insufficient stFLIP balance due to unstaking. If a user's stFLIP drops below their principal due to a slash, the `claimableRewards` calculation will underflow. 

# Tests
Test cases include three scenarios for reward claiming functionality - the mechanism is pretty straightforward. The tests are currently in a separate file for ease of development but they can be combined into original file later. Right now there are just cases for aggregation happy-path; I will add the unhappy path soon. 

## Mocks
stFLIP rewards are issued by transferring stFLIP to the vesting contract from another address. Slashes are performed by doing `mockBurn` which will burn a `value` from a given `address`. Within the `Aggregator` mock there is `mockAggregateMultiplier ` which can be set during tests to adjust the bonus/penalty a user will receive for a stake or unstake aggregation respectively. This is much simpler implementation than introducing a Curve pool into the repository. 


Note: the linter does not work locally for me thus the commits are not linted