### PR TITLE
ci:  fix ci failures

### DIFF
--- a/.github/actions/setup-python-env/action.yml
+++ b/.github/actions/setup-python-env/action.yml
@@ -1,0 +1,23 @@
+name: Setup Python environment
+description: Installs python3-venv, Poetry 1.4.1, and solc 0.8.20
+
+runs:
+  using: composite
+  steps:
+    - name: Install Python virtualenv
+      shell: bash
+      run: |
+        sudo apt-get install -y python3-venv
+        pip install virtualenv
+
+    - name: Install and configure Poetry
+      uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
+      with:
+        version: "1.4.1"
+
+    - name: Install solc
+      shell: bash
+      run: |
+        mkdir -p ~/.solcx
+        curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+        chmod +x ~/.solcx/solc-v0.8.20

--- a/.github/workflows/.lint.yml
+++ b/.github/workflows/.lint.yml
@@ -13,15 +13,8 @@ jobs:
         with:
           node-version: "14"
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install
       - run: npx solhint -w 0 'contracts/**/*.sol'

--- a/.github/workflows/.lint.yml
+++ b/.github/workflows/.lint.yml
@@ -14,7 +14,9 @@ jobs:
           node-version: "14"
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Install and configure Poetry
         uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a

--- a/.github/workflows/create-geth-arb-network.yml
+++ b/.github/workflows/create-geth-arb-network.yml
@@ -125,7 +125,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
@@ -283,7 +285,9 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
@@ -397,7 +401,9 @@ jobs:
       # Spamming Arbitrum so the final state contains all the previous funding transactions
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
@@ -563,7 +569,9 @@ jobs:
           docker compose up -d
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65

--- a/.github/workflows/create-geth-arb-network.yml
+++ b/.github/workflows/create-geth-arb-network.yml
@@ -124,20 +124,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -147,12 +140,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum docker host=http://localhost:8545 chainid=10997
@@ -290,20 +277,13 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -313,12 +293,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum bsc-docker host=http://localhost:8545 chainid=343
@@ -412,20 +386,13 @@ jobs:
 
       # Spamming Arbitrum so the final state contains all the previous funding transactions
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -435,12 +402,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum arb-l2 host=http://localhost:8547 chainid=412346
@@ -586,20 +547,13 @@ jobs:
           docker compose up init -d
           docker compose up -d
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -609,12 +563,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum arb-l2 host=http://localhost:8547 chainid=412346

--- a/.github/workflows/create-geth-arb-network.yml
+++ b/.github/workflows/create-geth-arb-network.yml
@@ -149,7 +149,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum docker host=http://localhost:8545 chainid=10997
@@ -312,7 +315,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum bsc-docker host=http://localhost:8545 chainid=343
@@ -431,7 +437,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum arb-l2 host=http://localhost:8547 chainid=412346
@@ -602,7 +611,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum arb-l2 host=http://localhost:8547 chainid=412346

--- a/.github/workflows/create-geth-arb-network.yml
+++ b/.github/workflows/create-geth-arb-network.yml
@@ -148,6 +148,9 @@ jobs:
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
 
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+
       - name: Add the network
         run: poetry run brownie networks add Ethereum docker host=http://localhost:8545 chainid=10997
 
@@ -308,6 +311,9 @@ jobs:
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
 
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+
       - name: Add the network
         run: poetry run brownie networks add Ethereum bsc-docker host=http://localhost:8545 chainid=343
 
@@ -423,6 +429,9 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
+
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum arb-l2 host=http://localhost:8547 chainid=412346
@@ -591,6 +600,9 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
+
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
 
       - name: Add the network
         run: poetry run brownie networks add Ethereum arb-l2 host=http://localhost:8547 chainid=412346

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,20 +12,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - name: Install zip
         run: |
@@ -40,12 +33,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       # Ensure that the Deposit's bytecode hasn't changed
       - run: poetry run brownie test tests/unit/vault/test_deployAndFetchBatch.py::test_getCreate2Addr --network hardhat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       # Ensure that the Deposit's bytecode hasn't changed
       - run: poetry run brownie test tests/unit/vault/test_deployAndFetchBatch.py::test_getCreate2Addr --network hardhat

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
 
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+
       # Ensure that the Deposit's bytecode hasn't changed
       - run: poetry run brownie test tests/unit/vault/test_deployAndFetchBatch.py::test_getCreate2Addr --network hardhat
 

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -49,6 +49,9 @@ jobs:
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
 
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+
       - run: npx hardhat node &
       - run: sleep 2
 

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -50,7 +50,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       - run: npx hardhat node &
       - run: sleep 2

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65

--- a/.github/workflows/scripts-tests.yml
+++ b/.github/workflows/scripts-tests.yml
@@ -25,20 +25,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -48,12 +41,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       - run: npx hardhat node &
       - run: sleep 2

--- a/.github/workflows/stateful-tests.yml
+++ b/.github/workflows/stateful-tests.yml
@@ -30,7 +30,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65

--- a/.github/workflows/stateful-tests.yml
+++ b/.github/workflows/stateful-tests.yml
@@ -54,7 +54,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       # Spinning hardhat node externally because there's some intermittent nasty bug when the node is shut down at
       # the end of some stateful test causing the tests to fail - it is confusingly logged as a Flaky inconsistent

--- a/.github/workflows/stateful-tests.yml
+++ b/.github/workflows/stateful-tests.yml
@@ -52,6 +52,10 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
+
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+
       # Spinning hardhat node externally because there's some intermittent nasty bug when the node is shut down at
       # the end of some stateful test causing the tests to fail - it is confusingly logged as a Flaky inconsistent
       # data generation that behaved differently between runs

--- a/.github/workflows/stateful-tests.yml
+++ b/.github/workflows/stateful-tests.yml
@@ -29,20 +29,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -52,12 +45,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       # Spinning hardhat node externally because there's some intermittent nasty bug when the node is shut down at
       # the end of some stateful test causing the tests to fail - it is confusingly logged as a Flaky inconsistent

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -24,20 +24,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
-      - name: Install Python virtualenv
-        run: |
-          sudo apt-get install -y python3-venv
-          pip install virtualenv
-
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65
         with:
           node-version: "18"
 
-      - name: Install and configure Poetry
-        uses: snok/install-poetry@76e04a911780d5b312d89783f7b1cd627778900a
-        with:
-          version: "1.4.1"
+      - name: Setup Python environment
+        uses: ./.github/actions/setup-python-env
 
       - run: npm install --global ganache-cli
       - run: npm install --global yarn
@@ -48,12 +41,6 @@ jobs:
       - run: |
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
-
-      - name: Install solc
-        run: |
-          mkdir -p ~/.solcx
-          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
-          chmod +x ~/.solcx/solc-v0.8.20
 
       - run: npx hardhat node &
       - run: sleep 2

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -49,6 +49,9 @@ jobs:
           sed -i '/^package-mode = false$/d' pyproject.toml
           poetry install
 
+      - name: Install solc
+        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+
       - run: npx hardhat node &
       - run: sleep 2
       - run: poetry run brownie test --network hardhat --stateful false

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -50,7 +50,10 @@ jobs:
           poetry install
 
       - name: Install solc
-        run: poetry run python -c "from solcx import install_solc; install_solc('v0.8.20')"
+        run: |
+          mkdir -p ~/.solcx
+          curl -fL https://github.com/ethereum/solidity/releases/download/v0.8.20/solc-static-linux -o ~/.solcx/solc-v0.8.20
+          chmod +x ~/.solcx/solc-v0.8.20
 
       - run: npx hardhat node &
       - run: sleep 2

--- a/.github/workflows/stateless-tests.yml
+++ b/.github/workflows/stateless-tests.yml
@@ -25,7 +25,9 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11
 
       - name: Install Python virtualenv
-        run: pip install virtualenv
+        run: |
+          sudo apt-get install -y python3-venv
+          pip install virtualenv
 
       - name: Setup Node
         uses: actions/setup-node@8f152de45cc393bb48ce5d89d36b731f54556e65


### PR DESCRIPTION
CI started failing without any changes to the codebase. Two separate issues were caused by changes to the self-hosted runner environment.

1. Poetry installation failing

snok/install-poetry uses Poetry's official installer, which creates an isolated virtualenv using Python's built-in venv module.

2. solc unavailable at test time

Brownie and py-solc-x both try to fetch a list of available solc versions from solc-bin.ethereum.org before downloading the compiler. 

The hypothesis is that these were installed either by default or cached from previous runs and that this is no longer the case. Therefore we now install it manually.