### PR TITLE
feat: set bsc node min gas price to 0.1 Gwei matching BSC Testnet 

### DIFF
--- a/ci/docker/bsc/config.toml
+++ b/ci/docker/bsc/config.toml
@@ -46,7 +46,7 @@ RemoteIncrSnapshotURL = ""
 [Eth.Miner]
 GasFloor = 0
 GasCeil = 35000000
-GasPrice = 1000000000
+GasPrice = 100000000 # 0.1 Gwei matches BSC Testnet and > BSC Mainnet of 0.05 Gwei
 Recommit = 10000000000
 VoteEnable = false
 MaxWaitProposalInSecs = 3
@@ -69,7 +69,7 @@ Locals = []
 NoLocals = true
 Journal = "transactions.rlp"
 Rejournal = 3600000000000
-PriceLimit = 1000000000
+PriceLimit = 100000000 # 0.1 Gwei matches BSC Testnet and > BSC Mainnet of 0.05 Gwei
 PriceBump = 10
 AccountSlots = 200
 GlobalSlots = 8000


### PR DESCRIPTION
Sets the minimum gas price of the bsc initial state to 0.1 Gwei to make it work for BSC testnet when in sysyiphos and perseverance and also on mainnet since the BSC mainnet minimum is 0.05 Gwei