### PR TITLE
chore: improve documentation, gas testing and remove nzAddr checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ Some EVM networks differ on gas costs. Also, the localnet hardhat node might dif
 
 ```bash
 poetry run brownie test tests/unit/vault/test_allBatch_gas.py --network sepolia --stateful false --gas
+# Run the specific test in isolation to get the specific gas consumption for that action.
+poetry run brownie test tests/unit/vault/test_allBatch_gas.py::test_allBatch_transfer_native --network sepolia --stateful false --gas
 ```
 
 ### Bytecode

--- a/README.md
+++ b/README.md
@@ -164,6 +164,20 @@ export REDEMPTION_DELAY=<redemption delay in seconds>
 poetry run brownie run deploy_contracts --network sepolia
 ```
 
+### Gas estimations
+
+The simplest way to run gas estimations locally for the main Vault AllBatch transaction is to run:
+
+```bash
+poetry run brownie test tests/unit/vault/test_allBatch_gas.py --network hardhat --stateful false --gas
+```
+
+Some EVM networks differ on gas costs. Also, the localnet hardhat node might differ from the real live network due to different configuration, fork etc.. The same tests can be run on a live network. Make sure to set the `SEED` environment and the endpoint rpc environment.
+
+```bash
+poetry run brownie test tests/unit/vault/test_allBatch_gas.py --network sepolia --stateful false --gas
+```
+
 ### Bytecode
 
 #### CBOR Metadata Hash and Absolute Paths

--- a/README.md
+++ b/README.md
@@ -134,23 +134,34 @@ poetry run brownie run deploy_contracts
 
 ### Live Test network
 
+The script automatically detects whether to run an Ethereum or secondary EVM deployment (Arbitrum, BNB) based on the chain ID. Ethereum requires extra parameters due to the staking contract.
+
+**All networks:**
+
 ```bash
 # get this id from Infura and/or Alchemy
 export WEB3_INFURA_PROJECT_ID=<Infura project id>
-export WEB3_ALCHEMY_PROJECT_ID=<Infura project id>
+export WEB3_ALCHEMY_PROJECT_ID=<Alchemy project id>
 # ensure that the ETH account associated with this seed has ETH on that network
 export SEED="<your seed phrase>"
 # Set an aggregate key, a governance address and a community address that you would like to use
 export AGG_KEY=<agg key with leading parity byte, hex format, no leading 0x>
 export GOV_KEY=<gov address, hex format, with leading 0x>
 export COMM_KEY=<comm address, hex format, with leading 0x>
-# Set genesis parameters
-export GENESIS_STAKE=<the stake each node should have at genesis> (default =
-50000000000000000000000)
-export NUM_GENESIS_VALIDATORS=<number of genesis validators in the chainspec you expect to start against this contract> (default = 5)
+```
 
-# deploy the contracts to goerli.
-poetry run brownie run deploy_contracts --network goerli
+**Ethereum only**:
+
+```bash
+# Set genesis parameters
+export GENESIS_STAKE=<the stake each node should have at genesis> (default = 50000000000000000000000)
+export NUM_GENESIS_VALIDATORS=<number of genesis validators in the chainspec you expect to start against this contract> (default = 5)
+export REDEMPTION_DELAY=<redemption delay in seconds>
+```
+
+```bash
+# deploy the contracts to Sepolia.
+poetry run brownie run deploy_contracts --network sepolia
 ```
 
 ### Bytecode

--- a/contracts/KeyManager.sol
+++ b/contracts/KeyManager.sol
@@ -28,7 +28,7 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
         Key memory initialAggKey,
         address initialGovKey,
         address initialCommKey
-    ) nzAddr(initialGovKey) nzAddr(initialCommKey) nzKey(initialAggKey) validAggKey(initialAggKey) {
+    ) nzAddr(initialGovKey) nzKey(initialAggKey) validAggKey(initialAggKey) {
         _aggKey = initialAggKey;
         _govKey = initialGovKey;
         _commKey = initialCommKey;
@@ -130,7 +130,6 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
     )
         external
         override
-        nzAddr(newGovKey)
         consumeKeyNonceKeyManager(sigData, keccak256(abi.encode(this.setGovKeyWithAggKey.selector, newGovKey)))
     {
         emit GovKeySetByAggKey(_govKey, newGovKey);
@@ -141,7 +140,7 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
      * @notice  Set a new governance key. Can only be called by current governance key
      * @param newGovKey    The new governance key to be set.
      */
-    function setGovKeyWithGovKey(address newGovKey) external override nzAddr(newGovKey) onlyGovernor {
+    function setGovKeyWithGovKey(address newGovKey) external override onlyGovernor {
         emit GovKeySetByGovKey(_govKey, newGovKey);
         _govKey = newGovKey;
     }
@@ -159,7 +158,6 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
     )
         external
         override
-        nzAddr(newCommKey)
         consumeKeyNonceKeyManager(sigData, keccak256(abi.encode(this.setCommKeyWithAggKey.selector, newCommKey)))
     {
         emit CommKeySetByAggKey(_commKey, newCommKey);
@@ -170,7 +168,7 @@ contract KeyManager is SchnorrSECP256K1, Shared, IKeyManager {
      * @notice  Update the Community Key. Can only be called by the current Community Key.
      * @param newCommKey   New Community key address.
      */
-    function setCommKeyWithCommKey(address newCommKey) external override onlyCommunityKey nzAddr(newCommKey) {
+    function setCommKeyWithCommKey(address newCommKey) external override onlyCommunityKey {
         emit CommKeySetByCommKey(_commKey, newCommKey);
         _commKey = newCommKey;
     }

--- a/contracts/Vault.sol
+++ b/contracts/Vault.sol
@@ -62,8 +62,8 @@ contract Vault is IVault, AggKeyNonceConsumer, GovernanceCommunityGuarded {
             // Ensure that the last validate time is not in the future
             require(lastValidateTime <= block.timestamp);
         } else {
-            // Check that the addresses have been initialized
-            require(newGovKey != address(0) && newCommKey != address(0));
+            // Check that the governance key has been initialized
+            require(newGovKey != address(0));
         }
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,10 @@
 import pytest
+import deploy as _deploy
 from consts import *
 from deploy import *
 from deploy import (
     deploy_Chainflip_contracts,
+    deploy_contracts_secondary_evm,
     deploy_new_multicall,
     deploy_new_cfReceiver,
 )
@@ -30,6 +32,28 @@ def cfDeploy(
         DeployerContract,
         AddressChecker,
     )
+
+
+# Minimal deployment for secondary EVM chains (only KeyManager, Vault and AddressChecker)
+@pytest.fixture(scope="module")
+def cf_minimal(a, KeyManager, Vault, AddressChecker):
+    seed = environ.get("SEED")
+    # If there is no seed used use the default hardhat test accounts
+    if seed:
+        deployer_index = int(environ.get("DEPLOYER_ACCOUNT_INDEX") or 0)
+        cf_accs = accounts.from_mnemonic(seed, count=10)
+        deployer = cf_accs[deployer_index]
+        alice = cf_accs[1]
+    else:
+        deployer = a[9]
+        alice = a[1]
+
+    cf = deploy_contracts_secondary_evm(deployer, KeyManager, Vault, AddressChecker)
+
+    cf.safekeeper = cf.gov
+    cf.SAFEKEEPER = cf.gov
+    cf.ALICE = alice
+    return cf
 
 
 # Deploy the contracts and set up common test environment
@@ -113,6 +137,13 @@ def redemptionRegistered(cf, fundedMin):
 @pytest.fixture(scope="module")
 def token(cf, Token):
     return cf.SAFEKEEPER.deploy(
+        Token, "NotAPonzi", "NAP", INIT_TOKEN_SUPPLY, DEFAULT_TOKEN_DECIMALS
+    )
+
+
+@pytest.fixture(scope="module")
+def token_minimal(cf_minimal, Token):
+    return cf_minimal.SAFEKEEPER.deploy(
         Token, "NotAPonzi", "NAP", INIT_TOKEN_SUPPLY, DEFAULT_TOKEN_DECIMALS
     )
 

--- a/tests/deploy.py
+++ b/tests/deploy.py
@@ -415,5 +415,5 @@ def deploy_price_feeds(deployer, PriceFeedMockContract, feed_descriptions):
 # the script. Therefore, we increase the required_confs for live networks only. No need to do it for testing
 # nor localnets/devnets - that is with hardhat (including forks), with id 31337, and geth image, with id 10997.
 def transaction_params():
-    network.priority_fee("1 gwei")
+    network.priority_fee("2 gwei")
     return 1 if chain.id in [hardhat, eth_localnet, arb_localnet] else 3

--- a/tests/unit/aggKeyNonceConsumer/test_updateKeyManager.py
+++ b/tests/unit/aggKeyNonceConsumer/test_updateKeyManager.py
@@ -110,12 +110,20 @@ def test_updateKeyManager_arbitrary_rev_omit(cf, mockKeyManagers, KeyManagerMock
             signed_call_cf(
                 cf, aggKeyNonceConsumer.updateKeyManager, km_zero_govKey, True
             )
-        with reverts("Transaction reverted without a reason string"):
-            signed_call_cf(
-                cf, aggKeyNonceConsumer.updateKeyManager, km_zero_commKey, True
-            )
+    # Vault no longer requires non-zero commKey; stateChainGateway still does
+    with reverts("Transaction reverted without a reason string"):
+        signed_call_cf(cf, cf.stateChainGateway.updateKeyManager, km_zero_commKey, True)
 
     _emergency_withdrawals(cf, cf.gov, cf.COMMUNITY_KEY)
+
+
+def test_updateKeyManager_vault_zero_commKey_omit(cf, KeyManagerMock5):
+    km_zero_commKey = cf.SAFEKEEPER.deploy(
+        KeyManagerMock5,
+        cf.keyManager.getGovernanceKey(),
+        ZERO_ADDR,
+    )
+    signed_call_cf(cf, cf.vault.updateKeyManager, km_zero_commKey, True)
 
 
 # Separating success tests because once a keyManagerMock is set the following ones will fail

--- a/tests/unit/keyManager/test_setCommKeyWithAggKey.py
+++ b/tests/unit/keyManager/test_setCommKeyWithAggKey.py
@@ -7,10 +7,3 @@ from shared_tests import *
 
 def test_setCommKeyWithAggKey(cf):
     setCommKeyWithAggKey_test(cf)
-
-
-def test_setCommKeyWithAggKey_rev(cf):
-    with reverts(REV_MSG_NZ_ADDR):
-        signed_call_cf(
-            cf, cf.keyManager.setCommKeyWithAggKey, ZERO_ADDR, sender=cf.ALICE
-        )

--- a/tests/unit/keyManager/test_setCommKeyWithCommKey.py
+++ b/tests/unit/keyManager/test_setCommKeyWithCommKey.py
@@ -7,11 +7,6 @@ def test_setCommKeyWithCommKey(cf):
     setCommKeyWithCommKey_test(cf)
 
 
-def test_setCommKeyWithCommKey_rev_nzAddr(cf):
-    with reverts(REV_MSG_NZ_ADDR):
-        cf.keyManager.setCommKeyWithCommKey(ZERO_ADDR, {"from": cf.COMMUNITY_KEY})
-
-
 def test_setCommKeyWithCommKey_rev_comm(cf):
     with reverts(REV_MSG_KEYMANAGER_NOT_COMMUNITY):
         cf.keyManager.setCommKeyWithCommKey(ZERO_ADDR, {"from": cf.ALICE})

--- a/tests/unit/keyManager/test_setGovKeyWithAggKey.py
+++ b/tests/unit/keyManager/test_setGovKeyWithAggKey.py
@@ -7,10 +7,3 @@ from shared_tests import *
 
 def test_setGovKeyWithAggKey(cf):
     setGovKeyWithAggKey_test(cf)
-
-
-def test_setGovKeyWithAggKey_rev(cf):
-    with reverts(REV_MSG_NZ_ADDR):
-        signed_call_cf(
-            cf, cf.keyManager.setGovKeyWithAggKey, ZERO_ADDR, sender=cf.ALICE
-        )

--- a/tests/unit/keyManager/test_setGovKeyWithGovKey.py
+++ b/tests/unit/keyManager/test_setGovKeyWithGovKey.py
@@ -10,8 +10,3 @@ def test_setGovKeyWithGovKey(cf):
 def test_setGovKeyWithGovKey_rev(cf):
     with reverts(REV_MSG_KEYMANAGER_GOVERNOR):
         cf.keyManager.setGovKeyWithGovKey(cf.ALICE, {"from": cf.ALICE})
-
-
-def test_setGovKeyWithGovKey_rev_nz(cf):
-    with reverts(REV_MSG_NZ_ADDR):
-        cf.keyManager.setGovKeyWithGovKey(ZERO_ADDR, {"from": cf.GOVERNOR})

--- a/tests/unit/vault/test_allBatch_gas.py
+++ b/tests/unit/vault/test_allBatch_gas.py
@@ -1,0 +1,89 @@
+import pytest
+from consts import *
+from utils import *
+from shared_tests import *
+
+
+@pytest.fixture(autouse=True)
+def isolation():
+    pass
+
+
+# Transferring one more to prevent the gas difference of the balance reduced to zero
+
+
+def test_allBatch_transfer_native(cf_minimal):
+    cf_minimal.SAFEKEEPER.transfer(cf_minimal.vault.address, TEST_AMNT + 1)
+    signed_call_cf(
+        cf_minimal,
+        cf_minimal.vault.allBatch,
+        [],
+        [],
+        [[NATIVE_ADDR, cf_minimal.ALICE, TEST_AMNT]],
+    )
+
+
+def test_allBatch_transfer_token(cf_minimal, token_minimal):
+    token_minimal.transfer(
+        cf_minimal.vault.address, TEST_AMNT + 1, {"from": cf_minimal.SAFEKEEPER}
+    )
+    signed_call_cf(
+        cf_minimal,
+        cf_minimal.vault.allBatch,
+        [],
+        [],
+        [[token_minimal.address, cf_minimal.ALICE, TEST_AMNT]],
+    )
+
+
+def test_allBatch_deploy_fetch(cf_minimal, token_minimal, Deposit):
+    native_swap_id = cleanHexStrPad(web3.toHex(1))
+    native_deposit_addr = getCreate2Addr(
+        cf_minimal.vault.address, native_swap_id, Deposit, cleanHexStrPad(NATIVE_ADDR)
+    )
+    cf_minimal.SAFEKEEPER.transfer(native_deposit_addr, TEST_AMNT)
+    signed_call_cf(
+        cf_minimal,
+        cf_minimal.vault.allBatch,
+        [[native_swap_id, NATIVE_ADDR]],
+        [],
+        [],
+    )
+
+    token_swap_id = cleanHexStrPad(web3.toHex(2))
+    token_deposit_addr = getCreate2Addr(
+        cf_minimal.vault.address,
+        token_swap_id,
+        Deposit,
+        cleanHexStrPad(token_minimal.address),
+    )
+    token_minimal.transfer(
+        token_deposit_addr, TEST_AMNT, {"from": cf_minimal.SAFEKEEPER}
+    )
+    signed_call_cf(
+        cf_minimal,
+        cf_minimal.vault.allBatch,
+        [[token_swap_id, token_minimal.address]],
+        [],
+        [],
+    )
+
+
+def test_allBatch_deploy_native(cf_minimal, token_minimal, Deposit):
+    token_swap_id = cleanHexStrPad(web3.toHex(2))
+    token_deposit_addr = getCreate2Addr(
+        cf_minimal.vault.address,
+        token_swap_id,
+        Deposit,
+        cleanHexStrPad(token_minimal.address),
+    )
+    token_minimal.transfer(
+        token_deposit_addr, TEST_AMNT, {"from": cf_minimal.SAFEKEEPER}
+    )
+    signed_call_cf(
+        cf_minimal,
+        cf_minimal.vault.allBatch,
+        [],
+        [[token_deposit_addr, token_minimal.address]],
+        [],
+    )


### PR DESCRIPTION
Add documentation and test for gas estimations.
Remove ` nzAddr` checks in the constructor and when updating keys so the key can be set to zero, as in some chains like BSC we won't  have a GovKey nor CommKey. The `nzAddr` for the GovKey in the constructor is kept because a GovKey is needed for inserting the initial AggKey.