### PR TITLE
feat: add a script that generates contract verification json input

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@
 #   make deploy-all       # deploy-eth + deploy-arb + deploy-bsc
 #   make deploy-summary   # print scripts/.artefacts/{eth,arb,bsc}.json
 #   make deploy-live NETWORK=goerli   # deploy to a live network (needs .env + RPC)
+#   make generate-verification-json CHAIN_ID=97   # Etherscan standard-json inputs
+#                         #   for that chain's deployments recorded in build/deployments
 #   make clean-build      # remove ./build (run once if you previously compiled
 #                         #   outside this image, e.g. a native macOS brownie run)
 #   make clean            # remove containers + named volumes
@@ -56,7 +58,7 @@ define deploy_chain
 		echo; echo "==== Deployed contracts ($(1), chainId $(2)) ===="; jq . scripts/.artefacts/$(3).json'
 endef
 
-.PHONY: build shell compile test verify-bytecode deploy deploy-eth deploy-arb deploy-bsc deploy-all deploy-summary deploy-live clean-build clean
+.PHONY: build shell compile test verify-bytecode deploy deploy-eth deploy-arb deploy-bsc deploy-all deploy-summary deploy-live generate-verification-json clean-build clean
 
 build:
 	$(COMPOSE) build
@@ -99,6 +101,12 @@ deploy-summary:
 deploy-live:
 	@test -n "$(NETWORK)" || { echo "Set NETWORK=<brownie-network>, e.g. make deploy-live NETWORK=goerli"; exit 1; }
 	$(RUN) brownie run deploy_contracts --network $(NETWORK)
+
+# CHAIN_ID selects which deployments to export from build/deployments/map.json;
+# the script runs against a local hardhat node and never touches the live network.
+generate-verification-json:
+	@test -n "$(CHAIN_ID)" || { echo "Set CHAIN_ID=<chain id>, e.g. make generate-verification-json CHAIN_ID=97"; exit 1; }
+	$(RUN) $(call WITH_NODE,brownie run generate_verification_json main $(CHAIN_ID) --network hardhat)
 
 clean-build:
 	rm -rf build

--- a/scripts/generate_verification_json.py
+++ b/scripts/generate_verification_json.py
@@ -1,0 +1,38 @@
+import json
+import os
+import sys
+
+import brownie
+
+DEPLOYMENTS_MAP = os.path.join("build", "deployments", "map.json")
+
+# Usage: brownie run generate_verification_json main <chain_id> --network hardhat
+# e.g.:  brownie run generate_verification_json main 97 --network hardhat
+
+
+def main(chain_id=None):
+    with open(DEPLOYMENTS_MAP) as f:
+        deployments = json.load(f)
+
+    if chain_id is None or str(chain_id) not in deployments:
+        sys.exit(
+            f"Unknown chain id: {chain_id}. "
+            f"Chains in {DEPLOYMENTS_MAP}: {sorted(deployments.keys())}"
+        )
+    chain_id = str(chain_id)
+
+    output_dir = os.path.join("build", f"verification-jsons-chain-{chain_id}")
+    os.makedirs(output_dir, exist_ok=True)
+
+    for name, addresses in deployments[chain_id].items():
+        container = getattr(brownie, name, None)
+        if container is None:
+            print(f"WARNING: no contract container for {name}, skipping")
+            continue
+
+        info = container.get_verification_info()
+        for address in addresses:
+            path = os.path.join(output_dir, f"{name}-{address}-verify.json")
+            with open(path, "w") as f:
+                json.dump(info["standard_json_input"], f)
+            print(f"Wrote {path} (chain {chain_id})")


### PR DESCRIPTION
This PR adds a script to generate the required json input for verifying contracts using the UI of EtherScan based explorers