### PR TITLE
feat: call send-l2 with wait param

### DIFF
--- a/.github/workflows/create-geth-arb-network.yml
+++ b/.github/workflows/create-geth-arb-network.yml
@@ -386,9 +386,10 @@ jobs:
           mkdir -p ./data
           chmod -R 777 ./data
           ./test-node.bash --init --detach
-          ./test-node.bash script send-l2 --to address_0x076d3803349fd5FB48863c5Fc33483cB2243C0Df --ethamount 10000
-          ./test-node.bash script send-l2 --to address_0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethamount 10000
-          ./test-node.bash script send-l2 --to address_0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --ethamount 10000
+          # --wait blocks until each tx is mined; without it a transfer can be silently dropped
+          ./test-node.bash script send-l2 --to address_0x076d3803349fd5FB48863c5Fc33483cB2243C0Df --ethamount 10000 --wait
+          ./test-node.bash script send-l2 --to address_0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266 --ethamount 10000 --wait
+          ./test-node.bash script send-l2 --to address_0x70997970C51812dc3A010C7d01b50e0d17dc79C8 --ethamount 10000 --wait
 
       # Spamming Arbitrum so the final state contains all the previous funding transactions
 


### PR DESCRIPTION
* This PR fixes the arb-init image build in create-geth-arb-network.yml by making sure that the transactions funding the initial accounts go through by using the wait param of the send-l2, which wait until the balance of the receiving account increased.
* Without this fix this error was seen: `Arbitrum transaction failure: Error: Returned error: insufficient funds for gas * price + value: address 0x70997970C51812dc3A010C7d01b50e0d17dc79C8 ` on the `arb-init` image.
* Note that the fix doesn't eagerly fail the create-geth-arb-network job but the failure would manifest in the job timing out.